### PR TITLE
ROS#94 - Timer driver implementation

### DIFF
--- a/arch/cortex-m/samv71-hal/src/drivers/mod.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/mod.rs
@@ -1,3 +1,4 @@
 //! This module contains all the drivers for supported peripherals.
 
+pub mod timer;
 pub mod watchdog;

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -85,8 +85,8 @@ where
             None => return Err(TimerConfigurationError::InvalidClockSource),
         };
 
-        // SAFETY: `ExternalClockSource::to_clock_source_id` should return valid register value
-        // or perform early exit due to `?`, so this should be safe.
+        // SAFETY: `ExternalClockSource::id` will either return a valid clock source ID from PAC,
+        // or None, which is handled above.
         match clock {
             ExternalClock::XC0 => reg.modify(|_, w| unsafe { w.tc0xc0s().bits(clock_source_id) }),
             ExternalClock::XC1 => reg.modify(|_, w| unsafe { w.tc1xc1s().bits(clock_source_id) }),

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -25,11 +25,11 @@ use self::timer_error::TimerConfigurationError;
 /// * `TimerMetadata` - PAC timer counter instance metadata, see `TcMetadata` private trait.
 pub struct Timer<TimerMetadata> {
     /// Channel 0.
-    pub channel_0: Channel<TimerMetadata, Ch0, Disabled, NotConfigured>,
+    pub channel_0: Option<Channel<TimerMetadata, Ch0, Disabled, NotConfigured>>,
     /// Channel 1.
-    pub channel_1: Channel<TimerMetadata, Ch1, Disabled, NotConfigured>,
+    pub channel_1: Option<Channel<TimerMetadata, Ch1, Disabled, NotConfigured>>,
     /// Channel 2.
-    pub channel_2: Channel<TimerMetadata, Ch2, Disabled, NotConfigured>,
+    pub channel_2: Option<Channel<TimerMetadata, Ch2, Disabled, NotConfigured>>,
     /// PhantomData for TC metadata.
     _tc_peripheral: PhantomData<TimerMetadata>,
 }
@@ -57,9 +57,9 @@ where
         let tc = unsafe { &*Instance::REGISTERS };
 
         Self {
-            channel_0: Channel::new(&tc.tc_channel0),
-            channel_1: Channel::new(&tc.tc_channel1),
-            channel_2: Channel::new(&tc.tc_channel2),
+            channel_0: Some(Channel::new(&tc.tc_channel0)),
+            channel_1: Some(Channel::new(&tc.tc_channel1)),
+            channel_2: Some(Channel::new(&tc.tc_channel2)),
 
             _tc_peripheral: PhantomData,
         }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -1,13 +1,17 @@
 //! Implementation of HAL Timer Counter driver.
-mod channel;
-mod channel_config;
+pub mod channel;
+pub mod channel_config;
 mod tc_metadata;
-mod timer_config;
-mod timer_error;
+pub mod timer_config;
+pub mod timer_error;
 
-pub use channel::*;
-pub use tc_metadata::*;
+use channel::*;
+use tc_metadata::*;
+
+pub use channel::Channel;
+pub use channel_config::*;
 pub use timer_config::*;
+pub use timer_error::*;
 
 use core::marker::PhantomData;
 
@@ -16,7 +20,7 @@ use self::timer_error::TimerConfigurationError;
 /// Structure representing a Timer instance.
 ///
 /// # Generic parameters
-/// * `TimerMetadata` - PAC timer counter instance metadata, see [`TcMetadata`](tc_metadata::TcMetadata) trait.
+/// * `TimerMetadata` - PAC timer counter instance metadata, see `TcMetadata` private trait.
 pub struct Timer<TimerMetadata> {
     /// Tuple with available channels.
     pub channels: (

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -22,13 +22,13 @@ use self::timer_error::TimerConfigurationError;
 /// # Generic parameters
 /// * `TimerMetadata` - PAC timer counter instance metadata, see `TcMetadata` private trait.
 pub struct Timer<TimerMetadata> {
-    /// Tuple with available channels.
-    pub channels: (
-        Channel<TimerMetadata, Ch0, Disabled, NotConfigured>,
-        Channel<TimerMetadata, Ch1, Disabled, NotConfigured>,
-        Channel<TimerMetadata, Ch2, Disabled, NotConfigured>,
-    ),
-
+    /// Channel 0.
+    pub channel_0: Channel<TimerMetadata, Ch0, Disabled, NotConfigured>,
+    /// Channel 1.
+    pub channel_1: Channel<TimerMetadata, Ch1, Disabled, NotConfigured>,
+    /// Channel 2.
+    pub channel_2: Channel<TimerMetadata, Ch2, Disabled, NotConfigured>,
+    /// PhantomData for TC metadata.
     _tc_peripheral: PhantomData<TimerMetadata>,
 }
 
@@ -55,11 +55,10 @@ where
         let tc = unsafe { &*Instance::REGISTERS };
 
         Self {
-            channels: (
-                Channel::new(&tc.tc_channel0),
-                Channel::new(&tc.tc_channel1),
-                Channel::new(&tc.tc_channel2),
-            ),
+            channel_0: Channel::new(&tc.tc_channel0),
+            channel_1: Channel::new(&tc.tc_channel1),
+            channel_2: Channel::new(&tc.tc_channel2),
+
             _tc_peripheral: PhantomData,
         }
     }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -89,7 +89,7 @@ where
         source: ExternalClockSource,
     ) -> Result<(), TimerConfigurationError> {
         let reg = &self.registers_ref().bmr;
-        let clock_source_id = match clock.source_id(source) {
+        let clock_source_id = match clock.to_source_id(source) {
             Some(id) => id,
             None => return Err(TimerConfigurationError::InvalidClockSource),
         };

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -72,7 +72,7 @@ where
     ///
     /// # Return
     /// `Ok(())` if configuration arguments are valid,
-    /// `Err(TimerConfigurationError::InvalidClockSourceForExternalClock)` otherwise.
+    /// `Err(TimerConfigurationError::InvalidClockSource)` otherwise.
     ///
     /// # Safety
     /// This function directly modifies the registers of a timer, but values put in these

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -4,6 +4,7 @@ pub mod channel_config;
 mod tc_metadata;
 pub mod timer_config;
 pub mod timer_error;
+pub mod waveform_config;
 
 use channel::*;
 use tc_metadata::*;
@@ -12,6 +13,7 @@ pub use channel::Channel;
 pub use channel_config::*;
 pub use timer_config::*;
 pub use timer_error::*;
+pub use waveform_config::*;
 
 use core::marker::PhantomData;
 
@@ -88,7 +90,7 @@ where
         source: ExternalClockSource,
     ) -> Result<(), TimerConfigurationError> {
         let reg = &self.registers_ref().bmr;
-        let clock_source_id = match clock.to_source_id(source) {
+        let clock_source_id = match clock.id(source) {
             Some(id) => id,
             None => return Err(TimerConfigurationError::InvalidClockSource),
         };

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -38,16 +38,6 @@ impl<Instance> Timer<Instance>
 where
     Instance: TcMetadata,
 {
-    /// Returns a reference to Timer's registers.
-    ///
-    /// # Safety
-    /// This function dereferences a raw pointer.
-    /// It's safe to use, as long as there aren't multiple instances of [`Timer`] sharing the same registers,
-    /// and existing instances of [`Timer`] are created only with [`new`](Timer::new()) method  
-    fn registers_ref(&self) -> &RegisterBlock {
-        unsafe { &*Instance::REGISTERS }
-    }
-
     /// Creates a new timer instance from PAC timer structure.
     ///
     /// # Parameters
@@ -104,5 +94,15 @@ where
         }
 
         Ok(())
+    }
+
+    /// Returns a reference to Timer's registers.
+    ///
+    /// # Safety
+    /// This function dereferences a raw pointer.
+    /// It's safe to use, as long as there aren't multiple instances of [`Timer`] sharing the same registers,
+    /// and existing instances of [`Timer`] are created only with [`new`](Timer::new()) method  
+    fn registers_ref(&self) -> &RegisterBlock {
+        unsafe { &*Instance::REGISTERS }
     }
 }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -73,13 +73,17 @@ where
     /// # Return
     /// `Ok(())` if configuration arguments are valid,
     /// `Err(TimerConfigurationError::InvalidClockSourceForExternalClock)` otherwise.
+    ///
+    /// # Safety
+    /// This function directly modifies the registers of a timer, but values put in these
+    /// registers come from PAC, so they should be valid.
     pub fn configure_external_clock_source(
         &self,
         clock: ExternalClock,
         source: ExternalClockSource,
     ) -> Result<(), TimerConfigurationError> {
         let reg = &self.registers_ref().bmr;
-        let clock_source_id = source.to_clock_source_id(clock)?;
+        let clock_source_id = clock.source_id(source)?;
 
         // SAFETY: `ExternalClockSource::to_clock_source_id` should return valid register value
         // or perform early exit due to `?`, so this should be safe.

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -21,7 +21,7 @@ use self::timer_error::TimerConfigurationError;
 
 /// Structure representing a Timer instance.
 ///
-/// # Generic parameters
+/// # Generic Parameters
 /// * `TimerMetadata` - PAC timer counter instance metadata, see `TcMetadata` private trait.
 pub struct Timer<TimerMetadata> {
     /// Channel 0.
@@ -48,7 +48,7 @@ where
         unsafe { &*Instance::REGISTERS }
     }
 
-    /// Create a new timer instance from PAC timer structure.
+    /// Creates a new timer instance from PAC timer structure.
     ///
     /// # Parameters
     /// * `_instance` - PAC Timer Counter instance, consumed on construction to prevent

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -1,5 +1,6 @@
 //! Implementation of HAL Timer Counter driver.
 mod channel;
+mod channel_config;
 mod tc_metadata;
 mod timer_config;
 mod timer_error;

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -8,10 +8,15 @@ use super::TcMetadata;
 
 /// Structure representing a timer's channel.
 pub struct Channel<Timer, ID, State, Mode> {
+    /// Timer channel's registers.
     registers: *const TC_CHANNEL,
+    /// PhantomData for Timer type.
     _timer: PhantomData<Timer>,
+    /// PhantomData for ID type.
     _id: PhantomData<ID>,
+    /// PhantomData for State type.
     _state: PhantomData<State>,
+    /// PhantomData for Mode type.
     _mode: PhantomData<Mode>,
 }
 

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -22,6 +22,7 @@ pub struct Channel<Timer, ID, State, Mode> {
 }
 
 /// Enumeration listing available channels.
+///
 /// It's value-level equivalent of ChannelId trait.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ChannelNo {
@@ -34,6 +35,7 @@ pub enum ChannelNo {
 }
 
 /// Trait representing channel's ID
+///
 /// It's type-level equivalent of ChannelNo enumeration.
 pub trait ChannelId {
     /// Numeric value od channel ID.
@@ -120,7 +122,7 @@ where
         }
     }
 
-    /// Get currently used clock source.
+    /// Returns currently used clock source.
     pub fn clock_source(&self) -> ChannelClock {
         let is_timer_peripheral_clock_used =
             self.registers_ref().emr.read().nodivclk().bit_is_set();
@@ -174,7 +176,7 @@ where
         self.registers_ref().rc.read().rc().bits() as u16
     }
 
-    /// Set the value of channel's `C` register.
+    /// Sets the value of channel's `C` register.
     ///
     /// # Implementation notes
     /// RC register is 32-bit, but all timer counters of SAMV71 MCUs are 16-bit, therefore
@@ -183,7 +185,7 @@ where
         self.registers_ref().rc.write(|w| w.rc().variant(rc as u32));
     }
 
-    /// Read channel's status register, and clean interrupt status flags after that.
+    /// Reads channel's status register, and clean interrupt status flags after that.
     ///
     /// # Safety
     /// **Reading status register will clear interrupt status flags**. If you are using interrupts,
@@ -212,7 +214,8 @@ where
         }
     }
 
-    /// Enable selected interrupts.
+    /// Enables selected interrupts.
+    ///
     /// State of other interrupts will not be changed.
     ///
     /// # Parameters
@@ -239,7 +242,8 @@ where
         });
     }
 
-    /// Disable selected interrupts.
+    /// Disables selected interrupts.
+    ///
     /// State of other interrupts will not be changed.
     ///
     /// # Parameters
@@ -292,7 +296,7 @@ where
         unsafe { &*self.registers }
     }
 
-    /// Transform the channel into a type with different state and/or mode.
+    /// Transforms the channel into a type with different state and/or mode.
     ///
     /// This is a helper function that allows to reduce state transition boilerplate to minimum.
     ///
@@ -331,7 +335,7 @@ where
     Timer: TcMetadata,
     ID: ChannelId,
 {
-    /// Create new timer channel.
+    /// Creates new timer channel.
     ///
     /// # Parameters
     /// * `channel` - Pointer to Timer Counter channel registers.
@@ -351,6 +355,7 @@ where
     }
 
     /// Resets the hardware state of the timer to correctly reflect it's typestate.
+    ///
     /// In this state, the function will disable timer's channel.
     /// Our typestate should always be treated as "hard" guarantee, to which the hardware
     /// state of timer's channel is always synchronized.
@@ -418,7 +423,7 @@ where
     Timer: TcMetadata,
     ID: ChannelId,
 {
-    /// Set waveform mode configuration.
+    /// Sets waveform mode configuration.
     pub fn configure(&self, config: WaveformModeConfig) {
         self.registers_ref().cmr_waveform_mode().write(|w| {
             w.cpcstop()

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -84,6 +84,51 @@ where
     State: ChannelState,
     Mode: ChannelMode,
 {
+    /// Returns current counter value read from channel's registers.
+    ///
+    /// # Implementation note
+    /// CV register is 32-bit, but all timer counters of SAMV71 MCUs are 16-bit, therefore
+    /// the returned value is casted to u16 to avoid confusion (or increase it, and make the user read MCU manual).
+    pub fn counter_value(&self) -> u16 {
+        self.registers_ref().cv.read().cv().bits() as u16
+    }
+
+    /// Returns current value of channel's `A` register.
+    ///
+    /// # Implementation note
+    /// RA register is 32-bit, but all timer counters of SAMV71 MCUs are 16-bit, therefore
+    /// the returned value is casted to u16 to avoid confusion (or increase it, and make the user read MCU manual).
+    pub fn ra(&self) -> u16 {
+        self.registers_ref().ra.read().ra().bits() as u16
+    }
+
+    /// Returns current value of channel's `B` register.
+    ///
+    /// # Implementation note
+    /// RB register is 32-bit, but all timer counters of SAMV71 MCUs are 16-bit, therefore
+    /// the returned value is casted to u16 to avoid confusion (or increase it, and make the user read MCU manual).
+    pub fn rb(&self) -> u16 {
+        self.registers_ref().rb.read().rb().bits() as u16
+    }
+
+    /// Returns current value of channel's `C` register.
+    ///
+    /// # Implementation note
+    /// RC register is 32-bit, but all timer counters of SAMV71 MCUs are 16-bit, therefore
+    /// the returned value is casted to u16 to avoid confusion (or increase it, and make the user read MCU manual).
+    pub fn rc(&self) -> u16 {
+        self.registers_ref().rc.read().rc().bits() as u16
+    }
+
+    /// Set the value of channel's `C` register.
+    ///
+    /// # Implementation note
+    /// RC register is 32-bit, but all timer counters of SAMV71 MCUs are 16-bit, therefore
+    /// this function accepts only u16 to avoid confusion (or increase it, and make the user read MCU manual).
+    pub fn set_rc(&self, rc: u16) {
+        self.registers_ref().rc.write(|w| w.rc().variant(rc as u32));
+    }
+
     /// Returns a reference to Channel's registers.
     ///
     /// # Safety
@@ -191,5 +236,13 @@ where
     pub fn disable(self) -> Channel<Timer, ID, Disabled, Mode> {
         self.registers_ref().ccr.write(|w| w.clkdis().set_bit());
         Channel::transform(self)
+    }
+
+    /// Triggers the channel via software, starting it.
+    ///
+    /// Channel instance does not store the state indicating whether the timer is running or not,
+    /// due to the fact that it can automatically stop without notifications, depending on configuration.
+    pub fn trigger(&self) {
+        self.registers_ref().ccr.write(|w| w.swtrg().set_bit());
     }
 }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -160,6 +160,76 @@ where
         }
     }
 
+    /// Enable selected interrupts.
+    /// State of other interrupts will not be changed.
+    ///
+    /// # Parameters
+    /// * `interrupts` - Structure with interrupts to be enabled. All interrupts set
+    ///                  to `true` will be enabled.
+    pub fn enable_interrupts(&self, interrupts: ChannelInterrupts) {
+        self.registers_ref().ier.write(|w| {
+            w.covfs()
+                .variant(interrupts.counter_overflow)
+                .lovrs()
+                .variant(interrupts.load_overrun)
+                .cpas()
+                .variant(interrupts.ra_compare)
+                .cpbs()
+                .variant(interrupts.rb_compare)
+                .cpcs()
+                .variant(interrupts.rc_compare)
+                .ldras()
+                .variant(interrupts.ra_load)
+                .ldrbs()
+                .variant(interrupts.rb_load)
+                .etrgs()
+                .variant(interrupts.external_trigger)
+        });
+    }
+
+    /// Disable selected interrupts.
+    /// State of other interrupts will not be changed.
+    ///
+    /// # Parameters
+    /// * `interrupts` - Structure with interrupts to be disabled. All interrupts set
+    ///                  to `true` will be disabled.
+    pub fn disable_interrupts(&self, interrupts: ChannelInterrupts) {
+        self.registers_ref().idr.write(|w| {
+            w.covfs()
+                .variant(interrupts.counter_overflow)
+                .lovrs()
+                .variant(interrupts.load_overrun)
+                .cpas()
+                .variant(interrupts.ra_compare)
+                .cpbs()
+                .variant(interrupts.rb_compare)
+                .cpcs()
+                .variant(interrupts.rc_compare)
+                .ldras()
+                .variant(interrupts.ra_load)
+                .ldrbs()
+                .variant(interrupts.rb_load)
+                .etrgs()
+                .variant(interrupts.external_trigger)
+        });
+    }
+
+    /// Returns the status (enabled/disabled) of channel's interrupts.
+    pub fn interrupts_masks(&self) -> ChannelInterrupts {
+        let masks = self.registers_ref().imr.read();
+
+        ChannelInterrupts {
+            counter_overflow: masks.covfs().bit(),
+            load_overrun: masks.lovrs().bit(),
+            ra_compare: masks.cpas().bit(),
+            rb_compare: masks.cpbs().bit(),
+            rc_compare: masks.cpcs().bit(),
+            ra_load: masks.ldras().bit(),
+            rb_load: masks.ldrbs().bit(),
+            external_trigger: masks.etrgs().bit(),
+        }
+    }
+
     /// Returns a reference to Channel's registers.
     ///
     /// # Safety

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -1,0 +1,106 @@
+//! Module representing timer counter's channel
+use core::marker::PhantomData;
+use pac::tc0::tc_channel::TC_CHANNEL;
+
+/// Structure representing a timer.
+pub struct Channel<Timer, ID, State, Mode> {
+    registers: *const TC_CHANNEL,
+    _timer: PhantomData<Timer>,
+    _id: PhantomData<ID>,
+    _state: PhantomData<State>,
+    _mode: PhantomData<Mode>,
+}
+
+/// Trait representing channel's ID
+pub trait ChannelId {
+    const ID: usize;
+}
+
+/// Empty structure representing Channel 0 ID
+pub struct Ch0;
+/// Empty structure representing Channel 1 ID
+pub struct Ch1;
+/// Empty structure representing Channel 2 ID
+pub struct Ch2;
+
+impl ChannelId for Ch0 {
+    const ID: usize = 0;
+}
+
+impl ChannelId for Ch1 {
+    const ID: usize = 1;
+}
+
+impl ChannelId for Ch2 {
+    const ID: usize = 2;
+}
+
+/// Trait representing channel's state
+pub trait ChannelState {}
+
+/// Empty structure representing timer's disabled state.
+pub struct Disabled;
+/// Empty structure representing timer's enabled state.
+pub struct Enabled;
+
+impl ChannelState for Disabled {}
+impl ChannelState for Enabled {}
+
+/// Trait representing channel's mode
+pub trait ChannelMode {}
+
+/// Empty structure representing not configured channel.
+pub struct NotConfigured;
+/// Empty structure representing channel in Waveform mode.
+pub struct WaveformMode;
+/// Empty structure representing channel in Capture mode.
+pub struct CaptureMode;
+
+impl ChannelMode for NotConfigured {}
+impl ChannelMode for WaveformMode {}
+impl ChannelMode for CaptureMode {}
+
+impl<Timer, ID, State, Mode> Channel<Timer, ID, State, Mode> {
+    /// Returns a reference to Channel's registers.
+    ///
+    /// # Safety
+    /// This function dereferences a raw pointer.
+    /// It's safe to use as long as Channel is created only using provided [`new`](Channel::new()) method via [`Timer`](super::Timer) instance,
+    /// as it guarantees that the pointer will be valid.
+    fn registers_ref(&self) -> &TC_CHANNEL {
+        unsafe { &*self.registers }
+    }
+}
+
+impl<Timer, ID> Channel<Timer, ID, Disabled, NotConfigured>
+where
+    ID: ChannelId,
+{
+    /// Create new timer channel.
+    ///
+    /// # Parameters
+    /// * `channel` - Pointer to Timer Counter channel registers.
+    ///
+    /// # Safety
+    /// This function should be called only by [`Timer`](super::Timer), not by the user.
+    /// It's safe to use, as long as no duplicate channels (sharing the same registers) exist.
+    pub(super) fn new(channel: *const TC_CHANNEL) -> Channel<Timer, ID, Disabled, NotConfigured> {
+        Self {
+            registers: channel,
+            _timer: PhantomData,
+            _id: PhantomData,
+            _state: PhantomData,
+            _mode: PhantomData,
+        }
+        .synced_with_hardware()
+    }
+
+    /// Resets the hardware state of the timer to correctly reflect it's typestate.
+    /// In this state, the function will disable timer's channel.
+    /// Our typestate should always be treated as "hard" guarantee, to which the hardware
+    /// state of timer's channel is always synchronized.
+    fn synced_with_hardware(self) -> Self {
+        self.registers_ref().ccr.write(|w| w.clkdis().set_bit());
+        self
+    }
+}

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -11,8 +11,22 @@ pub struct Channel<Timer, ID, State, Mode> {
     _mode: PhantomData<Mode>,
 }
 
+/// Enumeration listing available channels.
+/// It's value-level equivalent of ChannelId trait.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ChannelNo {
+    /// Channel 0.
+    Ch0 = 0,
+    /// Channel 1.
+    Ch1 = 1,
+    /// Channel 2.
+    Ch2 = 2,
+}
+
 /// Trait representing channel's ID
+/// It's type-level equivalent of ChannelNo enumeration.
 pub trait ChannelId {
+    /// Numeric value od channel ID.
     const ID: usize;
 }
 

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
@@ -1,6 +1,7 @@
 //! Module containing channel configuration and status structures.
 
 /// Structure representing available channel interrupts.
+#[derive(Debug, Eq, PartialEq)]
 pub struct ChannelInterrupts {
     pub counter_overflow: bool,
     /// RA or RB have been loaded at least twice without any read since last time the status was read)
@@ -13,7 +14,45 @@ pub struct ChannelInterrupts {
     pub external_trigger: bool,
 }
 
+impl ChannelInterrupts {
+    /// Create a `ChannelInterrupts` structure with all interrupts set to `true`
+    pub fn all() -> Self {
+        Self {
+            counter_overflow: true,
+            load_overrun: true,
+            ra_compare: true,
+            rb_compare: true,
+            rc_compare: true,
+            ra_load: true,
+            rb_load: true,
+            external_trigger: true,
+        }
+    }
+
+    /// Create a `ChannelInterrupts` structure with all interrupts set to `false`
+    pub fn none() -> Self {
+        Self {
+            counter_overflow: false,
+            load_overrun: false,
+            ra_compare: false,
+            rb_compare: false,
+            rc_compare: false,
+            ra_load: false,
+            rb_load: false,
+            external_trigger: false,
+        }
+    }
+}
+
+/// Explicit default, to explicitly indicate that default state is "all IRQs disabled"
+impl Default for ChannelInterrupts {
+    fn default() -> Self {
+        ChannelInterrupts::none()
+    }
+}
+
 /// Structure representing channel status register content.
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct ChannelStatus {
     /// Status of interrupts. Note that these flags are cleared when status register is read.
     pub interrupts: ChannelInterrupts,

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
@@ -74,10 +74,9 @@ pub struct ChannelStatus {
 }
 
 /// Enumeration listing available channel's clock sources.
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ChannelClock {
     /// PCK6 (or PCK7 for TC0 Ch0, if configured in PMC) clock signal from PMC
-    #[default]
     PmcPeripheralClock,
     /// Host clock divided by 8
     MckDividedBy8,

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
@@ -3,14 +3,21 @@
 /// Structure representing available channel interrupts.
 #[derive(Debug, Eq, PartialEq)]
 pub struct ChannelInterrupts {
+    /// Counter overflow
     pub counter_overflow: bool,
     /// RA or RB have been loaded at least twice without any read since last time the status was read)
     pub load_overrun: bool,
+    /// RA Compare
     pub ra_compare: bool,
+    /// RB Compare
     pub rb_compare: bool,
+    /// RC Compare
     pub rc_compare: bool,
+    /// RA Load
     pub ra_load: bool,
+    /// RB Load
     pub rb_load: bool,
+    /// External trigger
     pub external_trigger: bool,
 }
 
@@ -56,6 +63,7 @@ impl Default for ChannelInterrupts {
 pub struct ChannelStatus {
     /// Status of interrupts. Note that these flags are cleared when status register is read.
     pub interrupts: ChannelInterrupts,
+    /// Clock is enabled
     pub clock_enabled: bool,
     /// TIOA state - depending on config, it'll be either an internal signal, or a pin.
     pub tioa_state: bool,

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
@@ -1,0 +1,25 @@
+//! Module containing channel configuration and status structures.
+
+/// Structure representing available channel interrupts.
+pub struct ChannelInterrupts {
+    pub counter_overflow: bool,
+    /// RA or RB have been loaded at least twice without any read since last time the status was read)
+    pub load_overrun: bool,
+    pub ra_compare: bool,
+    pub rb_compare: bool,
+    pub rc_compare: bool,
+    pub ra_load: bool,
+    pub rb_load: bool,
+    pub external_trigger: bool,
+}
+
+/// Structure representing channel status register content.
+pub struct ChannelStatus {
+    /// Status of interrupts. Note that these flags are cleared when status register is read.
+    pub interrupts: ChannelInterrupts,
+    pub clock_enabled: bool,
+    /// TIOA state - depending on config, it'll be either an internal signal, or a pin.
+    pub tioa_state: bool,
+    /// TIOB state - depending on config, it'll be either an internal signal, or a pin.
+    pub tiob_state: bool,
+}

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
@@ -1,5 +1,7 @@
 //! Module containing channel configuration and status structures.
 
+use pac::tc0::tc_channel::cmr_capture_mode::TCCLKSSELECT_A;
+
 /// Structure representing available channel interrupts.
 #[derive(Debug, Eq, PartialEq)]
 pub struct ChannelInterrupts {
@@ -69,4 +71,55 @@ pub struct ChannelStatus {
     pub tioa_state: bool,
     /// TIOB state - depending on config, it'll be either an internal signal, or a pin.
     pub tiob_state: bool,
+}
+
+/// Enumeration listing available channel's clock sources.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub enum ChannelClock {
+    /// PCK6 (or PCK7 for TC0 Ch0) clock signal from PMC
+    #[default]
+    PmcPeripheralClock,
+    /// MCK divided by 8
+    MckDividedBy8,
+    /// MCK divided by 32
+    MckDividedBy32,
+    /// MCK divided by 128
+    MckDividedBy128,
+    /// Slow clock (SLCK)
+    SlowClock,
+    /// External clock 0
+    XC0,
+    /// External clock 1
+    XC1,
+    /// External clock 2
+    XC2,
+    /// Timer peripheral clock
+    TimerPeripheralClock,
+}
+
+impl ChannelClock {
+    /// Converts channel clock source to numeric ID representing it's value
+    /// in Channel's mode configuration register.
+    ///
+    /// To prevent accidental typos, returned values are taken directly from PAC.
+    /// This allows easy type erasure, while also retaining value safety.
+    ///
+    /// Not all values from this enumeration are meant to be written into CMR,
+    /// hence an Option is returned.
+    ///
+    /// # Returns
+    /// `Some(u8)` if current clock ID can be represented as value in CMR, otherwise None.
+    pub(super) fn clock_id(self) -> Option<u8> {
+        match self {
+            ChannelClock::PmcPeripheralClock => Some(TCCLKSSELECT_A::TIMER_CLOCK1 as u8),
+            ChannelClock::MckDividedBy8 => Some(TCCLKSSELECT_A::TIMER_CLOCK2 as u8),
+            ChannelClock::MckDividedBy32 => Some(TCCLKSSELECT_A::TIMER_CLOCK3 as u8),
+            ChannelClock::MckDividedBy128 => Some(TCCLKSSELECT_A::TIMER_CLOCK4 as u8),
+            ChannelClock::SlowClock => Some(TCCLKSSELECT_A::TIMER_CLOCK5 as u8),
+            ChannelClock::XC0 => Some(TCCLKSSELECT_A::XC0 as u8),
+            ChannelClock::XC1 => Some(TCCLKSSELECT_A::XC1 as u8),
+            ChannelClock::XC2 => Some(TCCLKSSELECT_A::XC2 as u8),
+            ChannelClock::TimerPeripheralClock => None,
+        }
+    }
 }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
@@ -6,6 +6,7 @@ use pac::{Interrupt, TC0, TC1, TC2, TC3};
 const CHANNELS_COUNT_PER_TIMER: usize = 3;
 
 /// Trait for PAC timer counter instances.
+///
 /// This trait erases the type of TC instance, so it can be used as generic argument for [`Timer`](super::Timer)
 pub trait TcMetadata {
     /// Pointer to Timer Counter's registers block.

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
@@ -1,6 +1,6 @@
 //! Module with PAC TC metadata implementation.
 pub(super) use pac::tc0::RegisterBlock;
-use pac::{Interrupt, TC0};
+use pac::{Interrupt, TC0, TC1, TC2, TC3};
 
 /// Amount of channels per timer instance.
 const CHANNELS_COUNT_PER_TIMER: usize = 3;
@@ -18,4 +18,22 @@ impl TcMetadata for TC0 {
     const REGISTERS: *const RegisterBlock = TC0::PTR;
     const INTERRUPTS: [Interrupt; CHANNELS_COUNT_PER_TIMER] =
         [Interrupt::TC0, Interrupt::TC1, Interrupt::TC2];
+}
+
+impl TcMetadata for TC1 {
+    const REGISTERS: *const RegisterBlock = TC1::PTR;
+    const INTERRUPTS: [Interrupt; CHANNELS_COUNT_PER_TIMER] =
+        [Interrupt::TC3, Interrupt::TC4, Interrupt::TC5];
+}
+
+impl TcMetadata for TC2 {
+    const REGISTERS: *const RegisterBlock = TC2::PTR;
+    const INTERRUPTS: [Interrupt; CHANNELS_COUNT_PER_TIMER] =
+        [Interrupt::TC6, Interrupt::TC7, Interrupt::TC8];
+}
+
+impl TcMetadata for TC3 {
+    const REGISTERS: *const RegisterBlock = TC3::PTR;
+    const INTERRUPTS: [Interrupt; CHANNELS_COUNT_PER_TIMER] =
+        [Interrupt::TC9, Interrupt::TC10, Interrupt::TC11];
 }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
@@ -1,0 +1,21 @@
+//! Module with PAC TC metadata implementation.
+pub(super) use pac::tc0::RegisterBlock;
+use pac::{Interrupt, TC0};
+
+/// Amount of channels per timer instance.
+const CHANNELS_COUNT_PER_TIMER: usize = 3;
+
+/// Trait for PAC timer counter instances.
+/// This trait erases the type of TC instance, so it can be used as generic argument for [`Timer`](super::Timer)
+pub trait TcMetadata {
+    /// Pointer to Timer Counter's registers block.
+    const REGISTERS: *const RegisterBlock;
+    /// Interrupt ID of each channel.
+    const INTERRUPTS: [Interrupt; CHANNELS_COUNT_PER_TIMER];
+}
+
+impl TcMetadata for TC0 {
+    const REGISTERS: *const RegisterBlock = TC0::PTR;
+    const INTERRUPTS: [Interrupt; CHANNELS_COUNT_PER_TIMER] =
+        [Interrupt::TC0, Interrupt::TC1, Interrupt::TC2];
+}

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
@@ -1,8 +1,12 @@
 //! Module containing configuration structures for Timer
 
+use super::timer_error::TimerConfigurationError;
+use pac::tc0::bmr::{TC0XC0SSELECT_A, TC1XC1SSELECT_A, TC2XC2SSELECT_A};
+
 /// External clock signal source.
 ///
 /// This represents available source clock signals for channel's external clock inputs.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ExternalClockSource {
     /// Timer clock (default source)
     TCLKx,
@@ -12,6 +16,58 @@ pub enum ExternalClockSource {
     TIOA1,
     /// Channel 2 output A
     TIOA2,
+}
+
+/// External clock signal.
+///
+/// This represents available external clock signals that can be used as timer channel's input clocks.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ExternalClock {
+    /// External Clock 0.
+    XC0,
+    /// External Clock 1.
+    XC1,
+    /// External Clock 2.
+    XC2,
+}
+
+impl ExternalClockSource {
+    /// Converts external clock source to numeric ID representing it's value
+    /// in Timer's Block Mode configuration register.
+    ///
+    /// # Parameters
+    /// * `channel` - Channel
+    pub(super) fn to_clock_source_id(
+        self,
+        clock: ExternalClock,
+    ) -> Result<u8, TimerConfigurationError> {
+        match clock {
+            ExternalClock::XC0 => match self {
+                ExternalClockSource::TCLKx => Ok(TC0XC0SSELECT_A::TCLK0 as u8),
+                ExternalClockSource::TIOA0 => {
+                    Err(TimerConfigurationError::InvalidClockSourceForExternalClock)
+                }
+                ExternalClockSource::TIOA1 => Ok(TC0XC0SSELECT_A::TIOA1 as u8),
+                ExternalClockSource::TIOA2 => Ok(TC0XC0SSELECT_A::TIOA2 as u8),
+            },
+            ExternalClock::XC1 => match self {
+                ExternalClockSource::TCLKx => Ok(TC1XC1SSELECT_A::TCLK1 as u8),
+                ExternalClockSource::TIOA0 => Ok(TC1XC1SSELECT_A::TIOA0 as u8),
+                ExternalClockSource::TIOA1 => {
+                    Err(TimerConfigurationError::InvalidClockSourceForExternalClock)
+                }
+                ExternalClockSource::TIOA2 => Ok(TC1XC1SSELECT_A::TIOA2 as u8),
+            },
+            ExternalClock::XC2 => match self {
+                ExternalClockSource::TCLKx => Ok(TC2XC2SSELECT_A::TCLK2 as u8),
+                ExternalClockSource::TIOA0 => Ok(TC2XC2SSELECT_A::TIOA0 as u8),
+                ExternalClockSource::TIOA1 => Ok(TC2XC2SSELECT_A::TIOA1 as u8),
+                ExternalClockSource::TIOA2 => {
+                    Err(TimerConfigurationError::InvalidClockSourceForExternalClock)
+                }
+            },
+        }
+    }
 }
 
 /// External clock signal selection configuration structure.

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
@@ -34,8 +34,9 @@ impl ExternalClock {
     /// Converts external clock source to numeric ID representing it's value
     /// in Timer's Block Mode configuration register.
     ///
-    /// To prevent accidental typos, returned values are taken directly from PAC.
-    /// This allows easy type erasure, while also retaining value safety.
+    /// To prevent accidental typos, returned values are taken directly from PAC
+    /// and converted to u8. This allows easy type erasure, while also retaining
+    /// value safety.
     ///
     /// # Parameters
     /// * `clock` - External clock source to apply for current clock.
@@ -43,7 +44,7 @@ impl ExternalClock {
     /// # Returns
     /// `Some(u8)` if conversion was successful, `None` if selected clock source
     /// cannot be connected to the external clock.
-    pub(super) fn source_id(self, clock: ExternalClockSource) -> Option<u8> {
+    pub(super) fn to_source_id(self, clock: ExternalClockSource) -> Option<u8> {
         match self {
             ExternalClock::XC0 => match clock {
                 ExternalClockSource::TCLKx => Some(TC0XC0SSELECT_A::TCLK0 as u8),

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
@@ -34,8 +34,12 @@ impl ExternalClock {
     /// Converts external clock source to numeric ID representing it's value
     /// in Timer's Block Mode configuration register.
     ///
-    /// To prevent accidental typos, returned values are taken directly from PAC
-    /// and converted to u8. This allows easy type erasure, while also retaining
+    /// Normally, [`From`] trait implementation would be used, but this enum values
+    /// are used in multiple registers fields, while also having different types
+    /// in PAC, so it's much less boilerplate to erase their type into u8.
+    ///
+    /// To prevent accidental typos, values are taken directly from PAC, and
+    /// converted to u8. This allows easy type erasure, while also retaining
     /// value safety.
     ///
     /// # Parameters
@@ -44,7 +48,7 @@ impl ExternalClock {
     /// # Returns
     /// `Some(u8)` if conversion was successful, `None` if selected clock source
     /// cannot be connected to the external clock.
-    pub(super) fn to_source_id(self, clock: ExternalClockSource) -> Option<u8> {
+    pub(super) fn id(self, clock: ExternalClockSource) -> Option<u8> {
         match self {
             ExternalClock::XC0 => match clock {
                 ExternalClockSource::TCLKx => Some(TC0XC0SSELECT_A::TCLK0 as u8),

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
@@ -31,46 +31,42 @@ pub enum ExternalClock {
     XC2,
 }
 
-impl ExternalClockSource {
+impl ExternalClock {
     /// Converts external clock source to numeric ID representing it's value
     /// in Timer's Block Mode configuration register.
     ///
+    /// To prevent accidental typos, returned values are taken directly from PAC.
+    /// This allows for easy type erasure, while also retaining value safety.
+    ///
     /// # Parameters
-    /// * `channel` - Channel
-    pub(super) fn to_clock_source_id(
+    /// * `clock` - External clock source to apply for current clock.
+    ///
+    /// # Returns
+    /// `Ok(u8)` if conversion was successful, `Err(TimerConfigurationError::InvalidClockSource)` if
+    /// selected clock source cannot be connected to the external clock.
+    pub(super) fn source_id(
         self,
-        clock: ExternalClock,
+        clock: ExternalClockSource,
     ) -> Result<u8, TimerConfigurationError> {
-        match clock {
-            ExternalClock::XC0 => match self {
+        match self {
+            ExternalClock::XC0 => match clock {
                 ExternalClockSource::TCLKx => Ok(TC0XC0SSELECT_A::TCLK0 as u8),
-                ExternalClockSource::TIOA0 => {
-                    Err(TimerConfigurationError::InvalidClockSourceForExternalClock)
-                }
+                ExternalClockSource::TIOA0 => Err(TimerConfigurationError::InvalidClockSource),
                 ExternalClockSource::TIOA1 => Ok(TC0XC0SSELECT_A::TIOA1 as u8),
                 ExternalClockSource::TIOA2 => Ok(TC0XC0SSELECT_A::TIOA2 as u8),
             },
-            ExternalClock::XC1 => match self {
+            ExternalClock::XC1 => match clock {
                 ExternalClockSource::TCLKx => Ok(TC1XC1SSELECT_A::TCLK1 as u8),
                 ExternalClockSource::TIOA0 => Ok(TC1XC1SSELECT_A::TIOA0 as u8),
-                ExternalClockSource::TIOA1 => {
-                    Err(TimerConfigurationError::InvalidClockSourceForExternalClock)
-                }
+                ExternalClockSource::TIOA1 => Err(TimerConfigurationError::InvalidClockSource),
                 ExternalClockSource::TIOA2 => Ok(TC1XC1SSELECT_A::TIOA2 as u8),
             },
-            ExternalClock::XC2 => match self {
+            ExternalClock::XC2 => match clock {
                 ExternalClockSource::TCLKx => Ok(TC2XC2SSELECT_A::TCLK2 as u8),
                 ExternalClockSource::TIOA0 => Ok(TC2XC2SSELECT_A::TIOA0 as u8),
                 ExternalClockSource::TIOA1 => Ok(TC2XC2SSELECT_A::TIOA1 as u8),
-                ExternalClockSource::TIOA2 => {
-                    Err(TimerConfigurationError::InvalidClockSourceForExternalClock)
-                }
+                ExternalClockSource::TIOA2 => Err(TimerConfigurationError::InvalidClockSource),
             },
         }
     }
 }
-
-/// External clock signal selection configuration structure.
-/// This can be used to configure external clock inputs for all channels at once,
-/// to reduce amount of writes performed to timer registers.
-pub type ExternalClockSignalSelectionConfig = [ExternalClockSource; 3];

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
@@ -1,6 +1,5 @@
 //! Module containing configuration structures for Timer
 
-use super::timer_error::TimerConfigurationError;
 use pac::tc0::bmr::{TC0XC0SSELECT_A, TC1XC1SSELECT_A, TC2XC2SSELECT_A};
 
 /// External clock signal source.
@@ -36,36 +35,33 @@ impl ExternalClock {
     /// in Timer's Block Mode configuration register.
     ///
     /// To prevent accidental typos, returned values are taken directly from PAC.
-    /// This allows for easy type erasure, while also retaining value safety.
+    /// This allows easy type erasure, while also retaining value safety.
     ///
     /// # Parameters
     /// * `clock` - External clock source to apply for current clock.
     ///
     /// # Returns
-    /// `Ok(u8)` if conversion was successful, `Err(TimerConfigurationError::InvalidClockSource)` if
-    /// selected clock source cannot be connected to the external clock.
-    pub(super) fn source_id(
-        self,
-        clock: ExternalClockSource,
-    ) -> Result<u8, TimerConfigurationError> {
+    /// `Some(u8)` if conversion was successful, `None` if selected clock source
+    /// cannot be connected to the external clock.
+    pub(super) fn source_id(self, clock: ExternalClockSource) -> Option<u8> {
         match self {
             ExternalClock::XC0 => match clock {
-                ExternalClockSource::TCLKx => Ok(TC0XC0SSELECT_A::TCLK0 as u8),
-                ExternalClockSource::TIOA0 => Err(TimerConfigurationError::InvalidClockSource),
-                ExternalClockSource::TIOA1 => Ok(TC0XC0SSELECT_A::TIOA1 as u8),
-                ExternalClockSource::TIOA2 => Ok(TC0XC0SSELECT_A::TIOA2 as u8),
+                ExternalClockSource::TCLKx => Some(TC0XC0SSELECT_A::TCLK0 as u8),
+                ExternalClockSource::TIOA0 => None,
+                ExternalClockSource::TIOA1 => Some(TC0XC0SSELECT_A::TIOA1 as u8),
+                ExternalClockSource::TIOA2 => Some(TC0XC0SSELECT_A::TIOA2 as u8),
             },
             ExternalClock::XC1 => match clock {
-                ExternalClockSource::TCLKx => Ok(TC1XC1SSELECT_A::TCLK1 as u8),
-                ExternalClockSource::TIOA0 => Ok(TC1XC1SSELECT_A::TIOA0 as u8),
-                ExternalClockSource::TIOA1 => Err(TimerConfigurationError::InvalidClockSource),
-                ExternalClockSource::TIOA2 => Ok(TC1XC1SSELECT_A::TIOA2 as u8),
+                ExternalClockSource::TCLKx => Some(TC1XC1SSELECT_A::TCLK1 as u8),
+                ExternalClockSource::TIOA0 => Some(TC1XC1SSELECT_A::TIOA0 as u8),
+                ExternalClockSource::TIOA1 => None,
+                ExternalClockSource::TIOA2 => Some(TC1XC1SSELECT_A::TIOA2 as u8),
             },
             ExternalClock::XC2 => match clock {
-                ExternalClockSource::TCLKx => Ok(TC2XC2SSELECT_A::TCLK2 as u8),
-                ExternalClockSource::TIOA0 => Ok(TC2XC2SSELECT_A::TIOA0 as u8),
-                ExternalClockSource::TIOA1 => Ok(TC2XC2SSELECT_A::TIOA1 as u8),
-                ExternalClockSource::TIOA2 => Err(TimerConfigurationError::InvalidClockSource),
+                ExternalClockSource::TCLKx => Some(TC2XC2SSELECT_A::TCLK2 as u8),
+                ExternalClockSource::TIOA0 => Some(TC2XC2SSELECT_A::TIOA0 as u8),
+                ExternalClockSource::TIOA1 => Some(TC2XC2SSELECT_A::TIOA1 as u8),
+                ExternalClockSource::TIOA2 => None,
             },
         }
     }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_config.rs
@@ -1,0 +1,20 @@
+//! Module containing configuration structures for Timer
+
+/// External clock signal source.
+///
+/// This represents available source clock signals for channel's external clock inputs.
+pub enum ExternalClockSource {
+    /// Timer clock (default source)
+    TCLKx,
+    /// Channel 0 output A
+    TIOA0,
+    /// Channel 1 output A
+    TIOA1,
+    /// Channel 2 output A
+    TIOA2,
+}
+
+/// External clock signal selection configuration structure.
+/// This can be used to configure external clock inputs for all channels at once,
+/// to reduce amount of writes performed to timer registers.
+pub type ExternalClockSignalSelectionConfig = [ExternalClockSource; 3];

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_error.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_error.rs
@@ -1,0 +1,10 @@
+//! Module containing timer-related error structures and traits.
+
+/// Timer configuration error.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum TimerConfigurationError {
+    /// Invalid channel ID was provided.
+    InvalidChannelId,
+    /// Invalid clock source was selected for external clock signal.
+    InvalidClockSourceForExternalClock,
+}

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_error.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_error.rs
@@ -3,8 +3,6 @@
 /// Timer configuration error.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TimerConfigurationError {
-    /// Invalid channel ID was provided.
-    InvalidChannelId,
     /// Invalid clock source was selected for external clock signal.
     InvalidClockSourceForExternalClock,
 }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/timer_error.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/timer_error.rs
@@ -3,6 +3,6 @@
 /// Timer configuration error.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TimerConfigurationError {
-    /// Invalid clock source was selected for external clock signal.
-    InvalidClockSourceForExternalClock,
+    /// Invalid clock source was selected.
+    InvalidClockSource,
 }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/waveform_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/waveform_config.rs
@@ -1,0 +1,228 @@
+//! Waveform-mode related configuration structures.
+
+use pac::tc0::tc_channel::cmr_waveform_mode::{
+    ACPASELECT_A, EEVTEDGSELECT_A, EEVTSELECT_A, WAVSELSELECT_A,
+};
+
+/// Structure representing waveform mode configuration.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct WaveformModeConfig {
+    /// Stop counter clock when counter reaches RC.
+    pub stop_clock_on_rc_compare: bool,
+    /// Disable counter clock when counter reaches RC.
+    pub disable_clock_on_rc_compare: bool,
+    /// External event configuration
+    pub external_event: ExternalEventConfig,
+    /// Waveform mode selection.
+    pub mode: WaveformMode,
+    /// Event effects for output A.
+    pub tioa_effects: OutputSignalEffects,
+    /// Event effects for output B.
+    pub tiob_effects: OutputSignalEffects,
+}
+
+impl Default for WaveformModeConfig {
+    /// Creates a default (per datasheet) config for Waveform mode
+    fn default() -> Self {
+        Self {
+            stop_clock_on_rc_compare: false,
+            disable_clock_on_rc_compare: false,
+            external_event: ExternalEventConfig {
+                edge: EventEdge::None,
+                signal: ExternalEventSignal::TIOB,
+                enabled: false,
+            },
+            mode: WaveformMode::Up,
+            tioa_effects: OutputSignalEffects::none(),
+            tiob_effects: OutputSignalEffects::none(),
+        }
+    }
+}
+
+/// Structure representing external event configuration for waveform mode.
+///
+/// Note: The selected external event only controls the TIOAx output and TIOBx
+/// if not used as input (trigger event input, or other input).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ExternalEventConfig {
+    /// External event signal edge.
+    pub edge: EventEdge,
+    /// External event signal source.
+    pub signal: ExternalEventSignal,
+    /// Do external event trigger resets the counter and starts the counter clock?
+    pub enabled: bool,
+}
+
+/// Structure representing event effects on channel's output signals (TIOA and TIOB)
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct OutputSignalEffects {
+    /// RA/RB comparison effect (RA for TIOA, RB for TIOB).
+    pub rx_comparison: ComparisonEffect,
+    /// RC comparison effect.
+    pub rc_comparison: ComparisonEffect,
+    /// External event effect.
+    pub external_event: ComparisonEffect,
+    /// Software trigger effect.
+    pub software_trigger: ComparisonEffect,
+}
+
+impl OutputSignalEffects {
+    /// Returns an [`OutputSignalEffects`] instance with all fields set to specific type of [effect](ComparisonEffect).
+    pub fn all(effect: ComparisonEffect) -> Self {
+        Self {
+            rx_comparison: effect,
+            rc_comparison: effect,
+            external_event: effect,
+            software_trigger: effect,
+        }
+    }
+
+    /// Returns an [`OutputSignalEffects`] instance with all fields set to [`ComparisonEffect::None`]
+    pub fn none() -> Self {
+        Self::all(ComparisonEffect::None)
+    }
+}
+
+/// Enumeration listing event signal edges.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum EventEdge {
+    /// None
+    None,
+    /// Rising edge
+    Rising,
+    /// Falling edge
+    Falling,
+    /// Each edge
+    Both,
+}
+
+impl From<EEVTEDGSELECT_A> for EventEdge {
+    fn from(value: EEVTEDGSELECT_A) -> Self {
+        match value {
+            EEVTEDGSELECT_A::NONE => EventEdge::None,
+            EEVTEDGSELECT_A::RISING => EventEdge::Rising,
+            EEVTEDGSELECT_A::FALLING => EventEdge::Falling,
+            EEVTEDGSELECT_A::EDGE => EventEdge::Both,
+        }
+    }
+}
+
+impl From<EventEdge> for EEVTEDGSELECT_A {
+    fn from(value: EventEdge) -> Self {
+        match value {
+            EventEdge::None => EEVTEDGSELECT_A::NONE,
+            EventEdge::Rising => EEVTEDGSELECT_A::RISING,
+            EventEdge::Falling => EEVTEDGSELECT_A::FALLING,
+            EventEdge::Both => EEVTEDGSELECT_A::EDGE,
+        }
+    }
+}
+
+/// Enumeration listing available external event signals.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ExternalEventSignal {
+    /// Timer Output B (TIOB becomes input)
+    ///
+    /// Note: if TIOB is chosen as the external event signal, it is configured
+    /// as an input and no longer generates waveforms, and subsequently, no interrupts.
+    TIOB,
+    /// External clock 0 (TIOB becomes output)
+    XC0,
+    /// External clock 1 (TIOB becomes output)
+    XC1,
+    /// External clock 2 (TIOB becomes output)
+    XC2,
+}
+
+impl From<EEVTSELECT_A> for ExternalEventSignal {
+    fn from(value: EEVTSELECT_A) -> Self {
+        match value {
+            EEVTSELECT_A::TIOB => ExternalEventSignal::TIOB,
+            EEVTSELECT_A::XC0 => ExternalEventSignal::XC0,
+            EEVTSELECT_A::XC1 => ExternalEventSignal::XC1,
+            EEVTSELECT_A::XC2 => ExternalEventSignal::XC2,
+        }
+    }
+}
+
+impl From<ExternalEventSignal> for EEVTSELECT_A {
+    fn from(value: ExternalEventSignal) -> Self {
+        match value {
+            ExternalEventSignal::TIOB => EEVTSELECT_A::TIOB,
+            ExternalEventSignal::XC0 => EEVTSELECT_A::XC0,
+            ExternalEventSignal::XC1 => EEVTSELECT_A::XC1,
+            ExternalEventSignal::XC2 => EEVTSELECT_A::XC2,
+        }
+    }
+}
+
+/// Enumeration listing available waveform counting modes.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum WaveformMode {
+    /// Counter counts "up" until it's triggered or overflows, then it's reset to 0.
+    Up,
+    /// Counters counts "up" until it's triggered or overflows,
+    /// then it counts "down" until it's triggered or reaches 0,
+    UpDown,
+    /// Counter counts "up" until it's triggered or reaches RC value, then it's reset to 0.
+    UpToRc,
+    /// Counters counts "up" until it's triggered or reaches RC value,
+    /// then it counts "down" until it's triggered or reaches 0,
+    UpDownToRc,
+}
+
+impl From<WAVSELSELECT_A> for WaveformMode {
+    fn from(value: WAVSELSELECT_A) -> Self {
+        match value {
+            WAVSELSELECT_A::UP => WaveformMode::Up,
+            WAVSELSELECT_A::UPDOWN => WaveformMode::UpDown,
+            WAVSELSELECT_A::UP_RC => WaveformMode::UpToRc,
+            WAVSELSELECT_A::UPDOWN_RC => WaveformMode::UpDownToRc,
+        }
+    }
+}
+
+impl From<WaveformMode> for WAVSELSELECT_A {
+    fn from(value: WaveformMode) -> Self {
+        match value {
+            WaveformMode::Up => WAVSELSELECT_A::UP,
+            WaveformMode::UpDown => WAVSELSELECT_A::UPDOWN,
+            WaveformMode::UpToRc => WAVSELSELECT_A::UP_RC,
+            WaveformMode::UpDownToRc => WAVSELSELECT_A::UPDOWN_RC,
+        }
+    }
+}
+
+/// Enumeration listing possible comparison effects.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ComparisonEffect {
+    /// Comparison has no effect on signal.
+    None,
+    /// Comparison sets the signal.
+    Set,
+    /// Comparison clears the signal.
+    Clear,
+    /// Comparison toggles the signal.
+    Toggle,
+}
+
+impl ComparisonEffect {
+    /// Converts comparison effect to numeric ID representing it's value in
+    /// channel's Waveform mode configuration register.
+    ///
+    /// Normally, [`From`] trait implementation would be used, but this enum values
+    /// are used in multiple registers fields, while also having different types
+    /// in PAC, so it's much less boilerplate to erase their type into u8.
+    ///
+    /// To prevent accidental typos, values are taken directly from PAC, and
+    /// converted to u8. This allows easy type erasure, while also retaining
+    /// value safety.
+    pub(super) fn id(self) -> u8 {
+        match self {
+            ComparisonEffect::None => ACPASELECT_A::NONE as u8,
+            ComparisonEffect::Set => ACPASELECT_A::SET as u8,
+            ComparisonEffect::Clear => ACPASELECT_A::CLEAR as u8,
+            ComparisonEffect::Toggle => ACPASELECT_A::TOGGLE as u8,
+        }
+    }
+}

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -69,6 +69,9 @@ impl Hal {
 
         let user_peripherals = UserPeripherals {
             chip_id: Some(mcu_peripherals.CHIPID),
+            timer_counter1: Some(mcu_peripherals.TC1),
+            timer_counter2: Some(mcu_peripherals.TC2),
+            timer_counter3: Some(mcu_peripherals.TC3),
         };
 
         (user_peripherals, system_peripherals)

--- a/arch/cortex-m/samv71-hal/src/user_peripherals.rs
+++ b/arch/cortex-m/samv71-hal/src/user_peripherals.rs
@@ -5,12 +5,12 @@ use pac;
 /// Peripherals structure.
 /// These peripherals can be used to create HAL drivers in user code.
 pub struct UserPeripherals {
-    /// Chip ID
+    /// Chip ID.
     pub chip_id: Option<pac::CHIPID>,
-    /// Timer Counter 1
+    /// Timer Counter 1.
     pub timer_counter1: Option<pac::TC1>,
-    /// Timer Counter 2
+    /// Timer Counter 2.
     pub timer_counter2: Option<pac::TC2>,
-    /// Timer Counter 3
+    /// Timer Counter 3.
     pub timer_counter3: Option<pac::TC3>,
 }

--- a/arch/cortex-m/samv71-hal/src/user_peripherals.rs
+++ b/arch/cortex-m/samv71-hal/src/user_peripherals.rs
@@ -5,6 +5,12 @@ use pac;
 /// Peripherals structure.
 /// These peripherals can be used to create HAL drivers in user code.
 pub struct UserPeripherals {
-    /// Chip ID.
+    /// Chip ID
     pub chip_id: Option<pac::CHIPID>,
+    /// Timer Counter 1
+    pub timer_counter1: Option<pac::TC1>,
+    /// Timer Counter 2
+    pub timer_counter2: Option<pac::TC2>,
+    /// Timer Counter 3
+    pub timer_counter3: Option<pac::TC3>,
 }


### PR DESCRIPTION
Added HAL Timer driver implementation, with functionality for
- Timer and Channel clock management
- Channel chaining
- Channel triggering (per channel, or all at once)
- Channel enabling/disabling and mode switching (using typestate pattern)
- Interrupt configuration (to be expanded with fully featured interrupt handler)
- Channel registers management (basic, to be expanded)
- Waveform mode configuration (basic, to be expanded)