### PR TITLE
ROS#94 - More Timer functionality and an example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ assert_cmd = "2.0"
 [features]
 use-aerugo-cortex-m = ["aerugo-cortex-m", "samv71-hal"]
 use-aerugo-x86 = ["aerugo-x86", "x86-hal"]
+rt = ["samv71-hal?/rt"]
 
 [profile.release]
 codegen-units = 1

--- a/arch/cortex-m/samv71-hal/Cargo.toml
+++ b/arch/cortex-m/samv71-hal/Cargo.toml
@@ -15,6 +15,9 @@ cortex-m = "0.7.7"
 bare-metal = "0.2.4"
 fugit = "0.3.6"
 samv71q21-pac = { version = "0.1.0", path = "../samv71q21-pac" }
-embedded-hal = { version = "0.2.7", features = ["unproven"] }
+embedded-hal = "0.2.7"
 aerugo-cortex-m = { version = "0.1.0", path = "../aerugo-cortex-m" }
 internal-cell = { version = "0.0.1", path = "../../../utils/internal_cell" }
+
+[features]
+rt = ["samv71q21-pac/rt"]

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -24,11 +24,11 @@ use self::{
 /// * `TimerMetadata` - PAC timer counter instance metadata, see `TcMetadata` private trait.
 pub struct Timer<TimerMetadata> {
     /// Channel 0.
-    pub channel_0: Option<Channel<TimerMetadata, Ch0, Disabled, NotConfigured>>,
+    pub channel_0: Option<Channel<TimerMetadata, Ch0, NotConfigured>>,
     /// Channel 1.
-    pub channel_1: Option<Channel<TimerMetadata, Ch1, Disabled, NotConfigured>>,
+    pub channel_1: Option<Channel<TimerMetadata, Ch1, NotConfigured>>,
     /// Channel 2.
-    pub channel_2: Option<Channel<TimerMetadata, Ch2, Disabled, NotConfigured>>,
+    pub channel_2: Option<Channel<TimerMetadata, Ch2, NotConfigured>>,
     /// PhantomData for TC metadata.
     _tc_peripheral: PhantomData<TimerMetadata>,
 }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -71,7 +71,7 @@ where
     ///
     /// # Safety
     /// This function directly modifies the registers of a timer in an unsafe manner, but values put in these
-    /// registers come from PAC, so they should be valid.
+    /// registers come from PAC and are validated before using, so they should be valid.
     pub fn configure_external_clock_source(
         &self,
         clock: ExternalClock,

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -1,6 +1,7 @@
 //! Implementation of HAL Timer Counter driver.
 pub mod channel;
 pub mod channel_config;
+pub mod channel_waveform;
 mod tc_metadata;
 pub mod timer_config;
 pub mod timer_error;

--- a/arch/cortex-m/samv71-hal/src/drivers/timer.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer.rs
@@ -6,18 +6,16 @@ pub mod timer_config;
 pub mod timer_error;
 pub mod waveform_config;
 
-use channel::*;
-use tc_metadata::*;
-
-pub use channel::Channel;
-pub use channel_config::*;
-pub use timer_config::*;
+pub use channel::*;
+pub use tc_metadata::*;
 pub use timer_error::*;
-pub use waveform_config::*;
 
 use core::marker::PhantomData;
 
-use self::timer_error::TimerConfigurationError;
+use self::{
+    timer_config::{ExternalClock, ExternalClockSource},
+    timer_error::TimerConfigurationError,
+};
 
 /// Structure representing a Timer instance.
 ///

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -19,6 +19,11 @@ pub struct Channel<Timer, ID, Mode> {
     _mode: PhantomData<Mode>,
 }
 
+/// Assuming that the user does not create an instance of channel by himself, and instead relies on
+/// instances provided by HAL, it's safe to share channel instances as there's only a single instance that can
+/// access hardware channel's registers at once, and it cannot be copied.
+unsafe impl<Timer, ID, Mode> Send for Channel<Timer, ID, Mode> {}
+
 /// Enumeration listing available channels.
 ///
 /// It's value-level equivalent of ChannelId trait.

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -4,8 +4,8 @@ use core::marker::PhantomData;
 use pac::tc0::tc_channel::TC_CHANNEL;
 
 use super::channel_config::*;
+use super::waveform_config::WaveformModeConfig;
 use super::TcMetadata;
-use super::WaveformModeConfig;
 
 /// Structure representing a timer's channel.
 pub struct Channel<Timer, ID, State, Mode> {

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel.rs
@@ -292,7 +292,7 @@ where
     /// This function dereferences a raw pointer.
     /// It's safe to use as long as Channel is created only using provided [`new`](Channel::new()) method via [`Timer`](super::Timer) instance,
     /// as it guarantees that the pointer will be valid.
-    fn registers_ref(&self) -> &TC_CHANNEL {
+    pub(super) fn registers_ref(&self) -> &TC_CHANNEL {
         unsafe { &*self.registers }
     }
 
@@ -414,48 +414,5 @@ where
     /// Triggers the channel via software, starting it.
     pub fn trigger(&self) {
         self.registers_ref().ccr.write(|w| w.swtrg().set_bit());
-    }
-}
-
-/// Channel implementation for Waveform mode while disabled.
-impl<Timer, ID> Channel<Timer, ID, Disabled, WaveformMode>
-where
-    Timer: TcMetadata,
-    ID: ChannelId,
-{
-    /// Sets waveform mode configuration.
-    pub fn configure(&self, config: WaveformModeConfig) {
-        self.registers_ref().cmr_waveform_mode().write(|w| {
-            w.cpcstop()
-                .variant(config.stop_clock_on_rc_compare)
-                .cpcdis()
-                .variant(config.disable_clock_on_rc_compare)
-                .eevtedg()
-                .variant(config.external_event.edge.into())
-                .eevt()
-                .variant(config.external_event.signal.into())
-                .enetrg()
-                .variant(config.external_event.enabled)
-                .wavsel()
-                .variant(config.mode.into())
-                .wave()
-                .set_bit()
-                .acpa()
-                .bits(config.tioa_effects.rx_comparison.id())
-                .acpc()
-                .bits(config.tioa_effects.rc_comparison.id())
-                .aeevt()
-                .bits(config.tioa_effects.external_event.id())
-                .aswtrg()
-                .bits(config.tioa_effects.software_trigger.id())
-                .bcpb()
-                .bits(config.tiob_effects.rx_comparison.id())
-                .bcpc()
-                .bits(config.tiob_effects.rc_comparison.id())
-                .beevt()
-                .bits(config.tiob_effects.external_event.id())
-                .bswtrg()
-                .bits(config.tiob_effects.software_trigger.id())
-        });
     }
 }

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_config.rs
@@ -74,9 +74,11 @@ pub struct ChannelStatus {
 }
 
 /// Enumeration listing available channel's clock sources.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub enum ChannelClock {
-    /// PCK6 (or PCK7 for TC0 Ch0, if configured in PMC) clock signal from PMC
+    /// PCK6 (or PCK7 for TC0 Ch0, if configured in PMC) clock signal from PMC.
+    /// Default per datasheet.
+    #[default]
     PmcPeripheralClock,
     /// Host clock divided by 8
     MckDividedBy8,

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_waveform.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_waveform.rs
@@ -1,0 +1,194 @@
+//! Module with functionalities of timer's channel in waveform mode.
+
+use pac::tc0::tc_channel::CMR_WAVEFORM_MODE;
+
+use super::{
+    waveform_config::{
+        ComparisonEffect, CountMode, ExternalEventConfig, OutputSignalEffects, RcCompareEffect,
+        RcCompareEffectFlags, WaveformModeConfig,
+    },
+    Channel, ChannelId, Disabled, TcMetadata, WaveformMode,
+};
+
+/// Channel implementation for Waveform mode while disabled.
+impl<Timer, ID> Channel<Timer, ID, Disabled, WaveformMode>
+where
+    Timer: TcMetadata,
+    ID: ChannelId,
+{
+    /// Sets waveform mode configuration.
+    pub fn configure(&self, config: WaveformModeConfig) {
+        let rc_event_flags: RcCompareEffectFlags = config.rc_compare_effect.into();
+
+        self.registers_ref().cmr_waveform_mode().write(|w| {
+            w.cpcstop()
+                .variant(rc_event_flags.stops)
+                .cpcdis()
+                .variant(rc_event_flags.disables)
+                .eevtedg()
+                .variant(config.external_event.edge.into())
+                .eevt()
+                .variant(config.external_event.signal.into())
+                .enetrg()
+                .variant(config.external_event.enabled)
+                .wavsel()
+                .variant(config.mode.into())
+                .wave()
+                .set_bit()
+                .acpa()
+                .bits(config.tioa_effects.rx_comparison.id())
+                .acpc()
+                .bits(config.tioa_effects.rc_comparison.id())
+                .aeevt()
+                .bits(config.tioa_effects.external_event.id())
+                .aswtrg()
+                .bits(config.tioa_effects.software_trigger.id())
+                .bcpb()
+                .bits(config.tiob_effects.rx_comparison.id())
+                .bcpc()
+                .bits(config.tiob_effects.rc_comparison.id())
+                .beevt()
+                .bits(config.tiob_effects.external_event.id())
+                .bswtrg()
+                .bits(config.tiob_effects.software_trigger.id())
+        });
+    }
+
+    /// Returns the effect of RC Compare event on channel's counter state.
+    pub fn rc_compare_effect(&self) -> RcCompareEffect {
+        let reg = self.mode_register().read();
+
+        RcCompareEffectFlags {
+            stops: reg.cpcstop().bit_is_set(),
+            disables: reg.cpcdis().bit_is_set(),
+        }
+        .into()
+    }
+
+    /// Sets the effect of RC Compare event on channel's counter state.
+    pub fn set_rc_compare_effect(&self, effect: RcCompareEffect) {
+        let flags: RcCompareEffectFlags = effect.into();
+
+        self.mode_register().modify(|_, w| {
+            w.cpcstop()
+                .variant(flags.stops)
+                .cpcdis()
+                .variant(flags.disables)
+        });
+    }
+
+    /// Returns current external event configuration.
+    pub fn external_event_config(&self) -> ExternalEventConfig {
+        let reg = self.mode_register().read();
+
+        ExternalEventConfig {
+            edge: reg.eevtedg().variant().into(),
+            signal: reg.eevt().variant().into(),
+            enabled: reg.enetrg().bit_is_set(),
+        }
+    }
+
+    /// Sets current external event configuration.
+    pub fn set_external_event_config(&self, config: ExternalEventConfig) {
+        self.mode_register().modify(|_, w| {
+            w.eevtedg()
+                .variant(config.edge.into())
+                .eevt()
+                .variant(config.signal.into())
+                .enetrg()
+                .variant(config.enabled)
+        });
+    }
+
+    /// Returns current counting mode.
+    pub fn count_mode(&self) -> CountMode {
+        self.mode_register().read().wavsel().variant().into()
+    }
+
+    /// Sets current counting mode.
+    pub fn set_count_mode(&self, mode: CountMode) {
+        self.mode_register()
+            .modify(|_, w| w.wavsel().variant(mode.into()));
+    }
+
+    /// Sets TIOA event/trigger effects.
+    ///
+    /// # Safety
+    /// This function will panic if an unexpected value is read from timer's registers.
+    /// If this happens, that means the PAC is broken and there's nothing that can be done on
+    /// user side to avoid it, as that kind of situation should never happen on correctly working
+    /// hardware. See [`ComparisonEffect::from_id`](ComparisonEffect::from_id) for details about
+    /// value conversion.
+    pub fn tioa_effects(&self) -> OutputSignalEffects {
+        let reg = self.mode_register().read();
+        let panic_message = "invalid comparison effect ID read from TC registers";
+
+        OutputSignalEffects {
+            rx_comparison: ComparisonEffect::from_id(reg.acpa().variant() as u8)
+                .expect(panic_message),
+            rc_comparison: ComparisonEffect::from_id(reg.acpc().variant() as u8)
+                .expect(panic_message),
+            external_event: ComparisonEffect::from_id(reg.aeevt().variant() as u8)
+                .expect(panic_message),
+            software_trigger: ComparisonEffect::from_id(reg.aswtrg().variant() as u8)
+                .expect(panic_message),
+        }
+    }
+
+    /// Returns TIOA event/trigger effects.
+    pub fn set_tioa_effects(&self, effects: OutputSignalEffects) {
+        self.mode_register().modify(|_, w| {
+            w.acpa()
+                .bits(effects.rx_comparison.id())
+                .acpc()
+                .bits(effects.rc_comparison.id())
+                .aeevt()
+                .bits(effects.external_event.id())
+                .aswtrg()
+                .bits(effects.software_trigger.id())
+        });
+    }
+
+    /// Sets TIOB event/trigger effects.
+    ///
+    /// # Safety
+    /// This function will panic if an unexpected value is read from timer's registers.
+    /// If this happens, that means the PAC is broken and there's nothing that can be done on
+    /// user side to avoid it, as that kind of situation should never happen on correctly working
+    /// hardware. See [`ComparisonEffect::from_id`](ComparisonEffect::from_id) for details about
+    /// value conversion.
+    pub fn tiob_effects(&self) -> OutputSignalEffects {
+        let reg = self.mode_register().read();
+        let panic_message = "invalid comparison effect ID read from TC registers";
+
+        OutputSignalEffects {
+            rx_comparison: ComparisonEffect::from_id(reg.bcpb().variant() as u8)
+                .expect(panic_message),
+            rc_comparison: ComparisonEffect::from_id(reg.bcpc().variant() as u8)
+                .expect(panic_message),
+            external_event: ComparisonEffect::from_id(reg.beevt().variant() as u8)
+                .expect(panic_message),
+            software_trigger: ComparisonEffect::from_id(reg.bswtrg().variant() as u8)
+                .expect(panic_message),
+        }
+    }
+
+    /// Returns TIOB event/trigger effects.
+    pub fn set_tiob_effects(&self, effects: OutputSignalEffects) {
+        self.mode_register().modify(|_, w| {
+            w.bcpb()
+                .bits(effects.rx_comparison.id())
+                .bcpc()
+                .bits(effects.rc_comparison.id())
+                .beevt()
+                .bits(effects.external_event.id())
+                .bswtrg()
+                .bits(effects.software_trigger.id())
+        });
+    }
+
+    /// Returns a reference to channel mode register.
+    fn mode_register(&self) -> &CMR_WAVEFORM_MODE {
+        self.registers_ref().cmr_waveform_mode()
+    }
+}

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_waveform.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_waveform.rs
@@ -132,7 +132,7 @@ where
     /// This function will panic if an unexpected value is read from timer's registers.
     /// If this happens, that means the PAC is broken and there's nothing that can be done on
     /// user side to avoid it, as that kind of situation should never happen on correctly working
-    /// hardware. See [`ComparisonEffect::from_id`](ComparisonEffect::from_id) for details about
+    /// hardware. See `ComparisonEffect::from_id`for details about
     /// value conversion.
     pub fn tioa_effects(&self) -> OutputSignalEffects {
         let reg = self.mode_register().read();
@@ -170,7 +170,7 @@ where
     /// This function will panic if an unexpected value is read from timer's registers.
     /// If this happens, that means the PAC is broken and there's nothing that can be done on
     /// user side to avoid it, as that kind of situation should never happen on correctly working
-    /// hardware. See [`ComparisonEffect::from_id`](ComparisonEffect::from_id) for details about
+    /// hardware. See `ComparisonEffect::from_id` for details about
     /// value conversion.
     pub fn tiob_effects(&self) -> OutputSignalEffects {
         let reg = self.mode_register().read();

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_waveform.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_waveform.rs
@@ -17,12 +17,12 @@ where
     ID: ChannelId,
 {
     /// Enables the channel.
-    pub fn enable(self) {
+    pub fn enable(&self) {
         self.registers_ref().ccr.write(|w| w.clken().set_bit());
     }
 
     /// Disables the channel.
-    pub fn disable(self) {
+    pub fn disable(&self) {
         self.registers_ref().ccr.write(|w| w.clkdis().set_bit());
     }
 

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/channel_waveform.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/channel_waveform.rs
@@ -126,7 +126,7 @@ where
             .modify(|_, w| w.wavsel().variant(mode.into()));
     }
 
-    /// Sets TIOA event/trigger effects.
+    /// Returns TIOA event/trigger effects.
     ///
     /// # Safety
     /// This function will panic if an unexpected value is read from timer's registers.
@@ -150,7 +150,7 @@ where
         }
     }
 
-    /// Returns TIOA event/trigger effects.
+    /// Sets TIOA event/trigger effects.
     pub fn set_tioa_effects(&self, effects: OutputSignalEffects) {
         self.mode_register().modify(|_, w| {
             w.acpa()
@@ -164,7 +164,7 @@ where
         });
     }
 
-    /// Sets TIOB event/trigger effects.
+    /// Returns TIOB event/trigger effects.
     ///
     /// # Safety
     /// This function will panic if an unexpected value is read from timer's registers.
@@ -188,7 +188,7 @@ where
         }
     }
 
-    /// Returns TIOB event/trigger effects.
+    /// Sets TIOB event/trigger effects.
     pub fn set_tiob_effects(&self, effects: OutputSignalEffects) {
         self.mode_register().modify(|_, w| {
             w.bcpb()

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
@@ -8,6 +8,7 @@ const CHANNELS_COUNT_PER_TIMER: usize = 3;
 /// Trait for PAC timer counter instances.
 ///
 /// This trait erases the type of TC instance, so it can be used as generic argument for [`Timer`](super::Timer)
+/// instead of concrete timer counter type.
 pub trait TcMetadata {
     /// Pointer to Timer Counter's registers block.
     const REGISTERS: *const RegisterBlock;

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/tc_metadata.rs
@@ -1,6 +1,7 @@
 //! Module with PAC TC metadata implementation.
 pub(super) use pac::tc0::RegisterBlock;
-use pac::{Interrupt, TC0, TC1, TC2, TC3};
+use pac::Interrupt;
+pub use pac::{TC0, TC1, TC2, TC3};
 
 /// Amount of channels per timer instance.
 const CHANNELS_COUNT_PER_TIMER: usize = 3;

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/waveform_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/waveform_config.rs
@@ -27,11 +27,7 @@ impl Default for WaveformModeConfig {
         Self {
             stop_clock_on_rc_compare: false,
             disable_clock_on_rc_compare: false,
-            external_event: ExternalEventConfig {
-                edge: EventEdge::None,
-                signal: ExternalEventSignal::TIOB,
-                enabled: false,
-            },
+            external_event: ExternalEventConfig::disabled(),
             mode: WaveformMode::Up,
             tioa_effects: OutputSignalEffects::none(),
             tiob_effects: OutputSignalEffects::none(),
@@ -51,6 +47,17 @@ pub struct ExternalEventConfig {
     pub signal: ExternalEventSignal,
     /// Do external event trigger resets the counter and starts the counter clock?
     pub enabled: bool,
+}
+
+impl ExternalEventConfig {
+    /// Returns disabled external event configuration.
+    pub fn disabled() -> Self {
+        ExternalEventConfig {
+            edge: EventEdge::None,
+            signal: ExternalEventSignal::TIOB,
+            enabled: false,
+        }
+    }
 }
 
 /// Structure representing event effects on channel's output signals (TIOA and TIOB)

--- a/arch/cortex-m/samv71-hal/src/drivers/timer/waveform_config.rs
+++ b/arch/cortex-m/samv71-hal/src/drivers/timer/waveform_config.rs
@@ -5,32 +5,88 @@ use pac::tc0::tc_channel::cmr_waveform_mode::{
 };
 
 /// Structure representing waveform mode configuration.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct WaveformModeConfig {
-    /// Stop counter clock when counter reaches RC.
-    pub stop_clock_on_rc_compare: bool,
-    /// Disable counter clock when counter reaches RC.
-    pub disable_clock_on_rc_compare: bool,
+    /// RC Compare event effect on timer's counter state.
+    pub rc_compare_effect: RcCompareEffect,
     /// External event configuration
     pub external_event: ExternalEventConfig,
     /// Waveform mode selection.
-    pub mode: WaveformMode,
+    pub mode: CountMode,
     /// Event effects for output A.
     pub tioa_effects: OutputSignalEffects,
     /// Event effects for output B.
     pub tiob_effects: OutputSignalEffects,
 }
 
-impl Default for WaveformModeConfig {
-    /// Creates a default (per datasheet) config for Waveform mode
-    fn default() -> Self {
-        Self {
-            stop_clock_on_rc_compare: false,
-            disable_clock_on_rc_compare: false,
-            external_event: ExternalEventConfig::disabled(),
-            mode: WaveformMode::Up,
-            tioa_effects: OutputSignalEffects::none(),
-            tiob_effects: OutputSignalEffects::none(),
+/// Enumeration representing RC compare event effect on channel's counter state.
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub enum RcCompareEffect {
+    /// RC Compare event has no effect on channel's counter state.
+    /// Default per datasheet.
+    #[default]
+    None,
+    /// RC Compare event stops channel's counter.
+    CounterStops,
+    /// RC Compare event disables channel's counter.
+    CounterDisables,
+    /// RC Compare event stops and disables channel's counter.
+    CounterStopsAndDisables,
+}
+
+/// Intermediate helper struct used for explicit conversions between enum value and it's flags in TC registers.
+/// To be used internally by HAL, not by the end user.
+pub(super) struct RcCompareEffectFlags {
+    /// Indicates that RC Compare stops the counter.
+    pub stops: bool,
+    /// Indicates that RC Compare disables the counter.
+    pub disables: bool,
+}
+
+/// Helper conversion trait, used to parse the enum value into TC register flags.
+impl From<RcCompareEffect> for RcCompareEffectFlags {
+    fn from(value: RcCompareEffect) -> Self {
+        match value {
+            RcCompareEffect::None => Self {
+                stops: false,
+                disables: false,
+            },
+            RcCompareEffect::CounterStops => Self {
+                stops: true,
+                disables: false,
+            },
+            RcCompareEffect::CounterDisables => Self {
+                stops: false,
+                disables: true,
+            },
+            RcCompareEffect::CounterStopsAndDisables => Self {
+                stops: true,
+                disables: true,
+            },
+        }
+    }
+}
+
+/// Helper conversion trait, used to parse data from TC registers into enum value.
+impl From<RcCompareEffectFlags> for RcCompareEffect {
+    fn from(value: RcCompareEffectFlags) -> Self {
+        match value {
+            RcCompareEffectFlags {
+                stops: false,
+                disables: false,
+            } => RcCompareEffect::None,
+            RcCompareEffectFlags {
+                stops: true,
+                disables: false,
+            } => RcCompareEffect::CounterStops,
+            RcCompareEffectFlags {
+                stops: false,
+                disables: true,
+            } => RcCompareEffect::CounterDisables,
+            RcCompareEffectFlags {
+                stops: true,
+                disables: true,
+            } => RcCompareEffect::CounterStopsAndDisables,
         }
     }
 }
@@ -39,7 +95,7 @@ impl Default for WaveformModeConfig {
 ///
 /// Note: The selected external event only controls the TIOAx output and TIOBx
 /// if not used as input (trigger event input, or other input).
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct ExternalEventConfig {
     /// External event signal edge.
     pub edge: EventEdge,
@@ -61,7 +117,7 @@ impl ExternalEventConfig {
 }
 
 /// Structure representing event effects on channel's output signals (TIOA and TIOB)
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct OutputSignalEffects {
     /// RA/RB comparison effect (RA for TIOA, RB for TIOB).
     pub rx_comparison: ComparisonEffect,
@@ -91,9 +147,11 @@ impl OutputSignalEffects {
 }
 
 /// Enumeration listing event signal edges.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub enum EventEdge {
     /// None
+    /// Default per datasheet for all scenarios.
+    #[default]
     None,
     /// Rising edge
     Rising,
@@ -126,12 +184,14 @@ impl From<EventEdge> for EEVTEDGSELECT_A {
 }
 
 /// Enumeration listing available external event signals.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub enum ExternalEventSignal {
     /// Timer Output B (TIOB becomes input)
     ///
     /// Note: if TIOB is chosen as the external event signal, it is configured
     /// as an input and no longer generates waveforms, and subsequently, no interrupts.
+    /// Default per datasheet.
+    #[default]
     TIOB,
     /// External clock 0 (TIOB becomes output)
     XC0,
@@ -164,9 +224,11 @@ impl From<ExternalEventSignal> for EEVTSELECT_A {
 }
 
 /// Enumeration listing available waveform counting modes.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum WaveformMode {
+#[derive(Debug, Copy, Default, Clone, Eq, PartialEq)]
+pub enum CountMode {
     /// Counter counts "up" until it's triggered or overflows, then it's reset to 0.
+    /// Default per datasheet.
+    #[default]
     Up,
     /// Counters counts "up" until it's triggered or overflows,
     /// then it counts "down" until it's triggered or reaches 0,
@@ -178,32 +240,34 @@ pub enum WaveformMode {
     UpDownToRc,
 }
 
-impl From<WAVSELSELECT_A> for WaveformMode {
+impl From<WAVSELSELECT_A> for CountMode {
     fn from(value: WAVSELSELECT_A) -> Self {
         match value {
-            WAVSELSELECT_A::UP => WaveformMode::Up,
-            WAVSELSELECT_A::UPDOWN => WaveformMode::UpDown,
-            WAVSELSELECT_A::UP_RC => WaveformMode::UpToRc,
-            WAVSELSELECT_A::UPDOWN_RC => WaveformMode::UpDownToRc,
+            WAVSELSELECT_A::UP => CountMode::Up,
+            WAVSELSELECT_A::UPDOWN => CountMode::UpDown,
+            WAVSELSELECT_A::UP_RC => CountMode::UpToRc,
+            WAVSELSELECT_A::UPDOWN_RC => CountMode::UpDownToRc,
         }
     }
 }
 
-impl From<WaveformMode> for WAVSELSELECT_A {
-    fn from(value: WaveformMode) -> Self {
+impl From<CountMode> for WAVSELSELECT_A {
+    fn from(value: CountMode) -> Self {
         match value {
-            WaveformMode::Up => WAVSELSELECT_A::UP,
-            WaveformMode::UpDown => WAVSELSELECT_A::UPDOWN,
-            WaveformMode::UpToRc => WAVSELSELECT_A::UP_RC,
-            WaveformMode::UpDownToRc => WAVSELSELECT_A::UPDOWN_RC,
+            CountMode::Up => WAVSELSELECT_A::UP,
+            CountMode::UpDown => WAVSELSELECT_A::UPDOWN,
+            CountMode::UpToRc => WAVSELSELECT_A::UP_RC,
+            CountMode::UpDownToRc => WAVSELSELECT_A::UPDOWN_RC,
         }
     }
 }
 
 /// Enumeration listing possible comparison effects.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Default, Clone, Eq, PartialEq)]
 pub enum ComparisonEffect {
     /// Comparison has no effect on signal.
+    /// Default per datasheet.
+    #[default]
     None,
     /// Comparison sets the signal.
     Set,
@@ -230,6 +294,29 @@ impl ComparisonEffect {
             ComparisonEffect::Set => ACPASELECT_A::SET as u8,
             ComparisonEffect::Clear => ACPASELECT_A::CLEAR as u8,
             ComparisonEffect::Toggle => ACPASELECT_A::TOGGLE as u8,
+        }
+    }
+
+    /// Converts comparison effect's ID from TC registers into a ComparisonEffect
+    /// instance.
+    ///
+    /// To prevent accidental typos, values are taken directly from PAC, and
+    /// converted to u8. This allows easy type erasure, while also retaining
+    /// value safety.
+    ///
+    /// # Returns
+    /// A [`ComparisonEffect`], or [`None`] if an invalid ID is provided.
+    pub(super) fn from_id(id: u8) -> Option<Self> {
+        if id == (ACPASELECT_A::NONE as u8) {
+            Some(ComparisonEffect::None)
+        } else if id == (ACPASELECT_A::SET as u8) {
+            Some(ComparisonEffect::Set)
+        } else if id == (ACPASELECT_A::CLEAR as u8) {
+            Some(ComparisonEffect::Clear)
+        } else if id == (ACPASELECT_A::TOGGLE as u8) {
+            Some(ComparisonEffect::Toggle)
+        } else {
+            None
         }
     }
 }

--- a/arch/cortex-m/samv71-hal/src/lib.rs
+++ b/arch/cortex-m/samv71-hal/src/lib.rs
@@ -19,3 +19,6 @@ pub mod user_peripherals;
 
 pub use self::hal::Hal;
 pub use embedded_hal;
+
+#[cfg(feature = "rt")]
+pub use pac::interrupt;

--- a/examples/samv71-hal-timer/.cargo/config.toml
+++ b/examples/samv71-hal-timer/.cargo/config.toml
@@ -1,0 +1,11 @@
+[build]
+target = "thumbv7em-none-eabihf"
+
+[env]
+AERUGO_TASKLET_COUNT = { value = "2" }
+
+[target.thumbv7em-none-eabihf]
+rustflags = [
+    "-C", "link-arg=--nmagic", # Disable page alignment of sections (to prevent issues with binary size)
+    "-C", "link-arg=-Tlink.x", # Use cortex-m-rt's linker script
+]

--- a/examples/samv71-hal-timer/Cargo.toml
+++ b/examples/samv71-hal-timer/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "samv71-hal-timer"
+authors = ["Wojciech Olech <wojciech_olech@hotmail.com>"]
+edition = "2021"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aerugo = { version = "0.1.0", path = "../..", features = [
+    "use-aerugo-cortex-m", "rt"
+] }
+cortex-m = { version = "0.7.7" }
+cortex-m-rt = { version = "0.7.3", features = ["device"] }
+cortex-m-semihosting = "0.5.0"
+panic-semihosting = "0.6.0"
+
+[features]
+rt = ["aerugo/rt"]

--- a/examples/samv71-hal-timer/build.rs
+++ b/examples/samv71-hal-timer/build.rs
@@ -1,0 +1,14 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+}

--- a/examples/samv71-hal-timer/memory.x
+++ b/examples/samv71-hal-timer/memory.x
@@ -1,0 +1,6 @@
+/* Linker script for SAMV71Q21 */
+MEMORY
+{
+    FLASH (rx) : ORIGIN = 0x00400000, LENGTH = 0x00200000
+    RAM (rwx) : ORIGIN = 0x20400000, LENGTH = 0x00060000
+}

--- a/examples/samv71-hal-timer/src/main.rs
+++ b/examples/samv71-hal-timer/src/main.rs
@@ -1,0 +1,119 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+
+use core::cell::RefCell;
+
+use aerugo::hal::drivers::timer::{
+    channel_config::ChannelClock, waveform_config::WaveformModeConfig, Ch0, Channel, Waveform, TC1,
+};
+use cortex_m::interrupt::free as irq_free;
+use cortex_m::interrupt::Mutex;
+use panic_semihosting as _;
+
+use aerugo::{
+    hal::drivers::timer::Timer, time::MillisDurationU32, InitApi, SystemHardwareConfig,
+    TaskletConfig, TaskletStorage, AERUGO,
+};
+use cortex_m_semihosting::hprintln;
+use rt::entry;
+
+static TIMER_CHANNEL: Mutex<RefCell<Option<Channel<TC1, Ch0, Waveform>>>> =
+    Mutex::new(RefCell::new(None));
+
+#[derive(Default)]
+struct DummyTaskContext {
+    acc: u16,
+}
+
+fn dummy_task(_: (), context: &mut DummyTaskContext) {
+    context.acc = context.acc.wrapping_add(1);
+    if context.acc % 1000 == 0 {
+        hprintln!("I'm running!");
+
+        irq_free(|cs| {
+            // This is safe, because TIMER_CHANNEL is set before the scheduler starts.
+            let timer_value = TIMER_CHANNEL
+                .borrow(cs)
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .counter_value();
+            hprintln!("TC1 CH0: {}", timer_value);
+        })
+    }
+}
+
+static DUMMY_TASK_STORAGE: TaskletStorage<(), DummyTaskContext> = TaskletStorage::new();
+
+fn init_timer(timer: &mut Timer<TC1>) {
+    let ch0 = timer
+        .channel_0
+        .take()
+        .expect("Channel 0 of Timer 1 already taken")
+        .into_waveform_channel(WaveformModeConfig::default());
+    ch0.set_clock_source(ChannelClock::MckDividedBy8);
+    ch0.enable();
+    ch0.trigger();
+
+    let status = ch0.read_and_clear_status().clock_enabled;
+    hprintln!("Clock is {}", if status { "enabled" } else { "disabled" });
+
+    irq_free(|cs| {
+        TIMER_CHANNEL.borrow(cs).replace(Some(ch0));
+    });
+}
+
+fn init_tasks() {
+    hprintln!("Creating tasks...");
+    let dummy_task_config = TaskletConfig {
+        name: "DummyTask",
+        ..Default::default()
+    };
+    let dummy_task_context = DummyTaskContext::default();
+
+    AERUGO
+        .create_tasklet_with_context(
+            dummy_task_config,
+            dummy_task,
+            dummy_task_context,
+            &DUMMY_TASK_STORAGE,
+        )
+        .expect("Unable to create dummy task!");
+
+    let dummy_task_handle = DUMMY_TASK_STORAGE
+        .create_handle()
+        .expect("Unable to create handle to dummy task!");
+
+    hprintln!("Subscribing tasks...");
+
+    AERUGO
+        .subscribe_tasklet_to_cyclic(&dummy_task_handle, None)
+        .expect("Unable to subscribe dummy task to cyclic execution!");
+}
+
+#[entry]
+fn main() -> ! {
+    hprintln!("Hello, world! Initializing Aerugo...");
+
+    AERUGO.initialize(SystemHardwareConfig {
+        watchdog_timeout: MillisDurationU32::secs(5),
+    });
+
+    hprintln!("Doing stuff with timers...");
+    let peripherals = AERUGO
+        .peripherals()
+        .expect("peripherals are not initialized")
+        .expect("peripherals already taken");
+
+    let mut timer = Timer::new(peripherals.timer_counter1.expect("Timer 1 already used"));
+    // TODO when PMC driver is done: actually enable timer clock so it starts correctly.
+    init_timer(&mut timer);
+
+    init_tasks();
+
+    hprintln!("Starting the system!");
+    AERUGO.start();
+}


### PR DESCRIPTION
- Refactored `Channel` struct (removed `Enabled`/`Disabled` typestate, as it's not possible to keep it synced with the hardware in every scenario)
- Added missing configuration functions
- Added an example
- Cleaned up documentation and exports