### PR TITLE
ROS#139: HAL initialization refactor

### DIFF
--- a/aerugo-hal/src/system_hal.rs
+++ b/aerugo-hal/src/system_hal.rs
@@ -22,10 +22,6 @@ pub trait SystemHal {
     /// Type for system HAL error.
     type Error;
 
-    /// Creates global HAL instance. Since there can only be a single instance of HAL, this function
-    /// should initialize it's global state and prepare the environment for hardware configuration.
-    fn initialize() -> Result<(), Self::Error>;
-
     /// Configure system hardware.
     ///
     /// Implementation should initialize and configure all core system peripherals.

--- a/aerugo-hal/src/system_hal.rs
+++ b/aerugo-hal/src/system_hal.rs
@@ -24,7 +24,7 @@ pub trait SystemHal {
 
     /// Creates global HAL instance. Since there can only be a single instance of HAL, this function
     /// should initialize it's global state and prepare the environment for hardware configuration.
-    fn create() -> Result<(), Self::Error>;
+    fn initialize() -> Result<(), Self::Error>;
 
     /// Configure system hardware.
     ///

--- a/aerugo-hal/src/system_hal.rs
+++ b/aerugo-hal/src/system_hal.rs
@@ -22,19 +22,23 @@ pub trait SystemHal {
     /// Type for system HAL error.
     type Error;
 
+    /// Creates global HAL instance. Since there can only be a single instance of HAL, this function
+    /// should initialize it's global state and prepare the environment for hardware configuration.
+    fn create() -> Result<(), Self::Error>;
+
     /// Configure system hardware.
     ///
     /// Implementation should initialize and configure all core system peripherals.
     ///
     /// # Parameters
     /// * `config` - System hardware configuration.
-    fn configure_hardware(&mut self, config: SystemHardwareConfig) -> Result<(), Self::Error>;
+    fn configure_hardware(config: SystemHardwareConfig) -> Result<(), Self::Error>;
 
     /// Gets current system time timestamp.
-    fn get_system_time(&self) -> Self::Instant;
+    fn get_system_time() -> Self::Instant;
 
     /// Feeds the system watchdog.
-    fn feed_watchdog(&mut self);
+    fn feed_watchdog();
 
     /// Enters critical section
     fn enter_critical();

--- a/arch/cortex-m/samv71-hal/src/error.rs
+++ b/arch/cortex-m/samv71-hal/src/error.rs
@@ -3,10 +3,10 @@
 /// HAL initialization error.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum HalError {
-    /// Error indicating that HAL has already been created once.
+    /// Error indicating that the requested operation was called before HAL creation.
+    HalNotCreated,
+    /// Error indicating that HAL was tried to be created twice.
     HalAlreadyCreated,
-    /// Error indicating that HAL has already been configured.
-    HalAlreadyConfigured,
-    /// Error indicating that the requested operation was called before HAL initialization.
-    HalNotInitializedYet,
+    /// Error indicating that system was tried to be initialized twice.
+    SystemAlreadyInitialized,
 }

--- a/arch/cortex-m/samv71-hal/src/error.rs
+++ b/arch/cortex-m/samv71-hal/src/error.rs
@@ -4,9 +4,9 @@
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum HalError {
     /// Error indicating that the requested operation was called before HAL creation.
-    HalNotCreated,
+    HalNotInitialized,
     /// Error indicating that HAL was tried to be created twice.
-    HalAlreadyCreated,
+    HalAlreadyInitialized,
     /// Error indicating that system was tried to be initialized twice.
-    SystemAlreadyInitialized,
+    HardwareAlreadyInitialized,
 }

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -33,31 +33,6 @@ impl Hal {
     /// Frequency of system timer.
     const TIMER_FREQ: u32 = 1_000_000;
 
-    /// Create system peripherals of HAL.
-    ///
-    /// This function steals PAC peripherals and returns a [`SystemPeripherals`] structure
-    /// containing peripherals used by [`SystemHal`] API implementation.
-    ///
-    /// Some of these peripherals will be accessible only during HAL initialization
-    /// (between [`Hal::create`] and [`SystemHal::configure_hardware`] calls).
-    ///
-    /// # Safety
-    /// This function should be only called once inside [`Hal::create`].
-    /// Subsequent calls will return valid peripherals, but it's not possible to
-    /// guarantee safety if multiple instances of peripherals are used in the system.
-    fn create_system_peripherals() -> SystemPeripherals {
-        let mcu_peripherals = unsafe { pac::Peripherals::steal() };
-
-        SystemPeripherals {
-            watchdog: Watchdog::new(mcu_peripherals.WDT),
-            timer: Timer::new(mcu_peripherals.TC0),
-            timer_ch0: None,
-            timer_ch1: None,
-            timer_ch2: None,
-            pmc: Some(mcu_peripherals.PMC),
-        }
-    }
-
     /// Creates user peripherals instance.
     ///
     /// This function steals PAC peripherals and returns a [`UserPeripherals`] structure
@@ -98,6 +73,31 @@ impl Hal {
                 None
             }
         })
+    }
+
+    /// Create system peripherals of HAL.
+    ///
+    /// This function steals PAC peripherals and returns a [`SystemPeripherals`] structure
+    /// containing peripherals used by [`SystemHal`] API implementation.
+    ///
+    /// Some of these peripherals will be accessible only during HAL initialization
+    /// (between [`Hal::create`] and [`SystemHal::configure_hardware`] calls).
+    ///
+    /// # Safety
+    /// This function should be only called once inside [`Hal::create`].
+    /// Subsequent calls will return valid peripherals, but it's not possible to
+    /// guarantee safety if multiple instances of peripherals are used in the system.
+    fn create_system_peripherals() -> SystemPeripherals {
+        let mcu_peripherals = unsafe { pac::Peripherals::steal() };
+
+        SystemPeripherals {
+            watchdog: Watchdog::new(mcu_peripherals.WDT),
+            timer: Timer::new(mcu_peripherals.TC0),
+            timer_ch0: None,
+            timer_ch1: None,
+            timer_ch2: None,
+            pmc: Some(mcu_peripherals.PMC),
+        }
     }
 }
 

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -120,7 +120,7 @@ impl SystemHal for Hal {
     ///
     /// # Return
     /// `()` on success, [`HalError::HalAlreadyCreated`] if called more than once.
-    fn create() -> Result<(), HalError> {
+    fn initialize() -> Result<(), HalError> {
         Hal::execute_critical(|_| {
             // SAFETY:
             // This function can be successfully called only once, and we're in critical section,

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -111,11 +111,8 @@ impl Hal {
     /// This function steals PAC peripherals and returns a [`SystemPeripherals`] structure
     /// containing peripherals used by [`SystemHal`] API implementation.
     ///
-    /// Some of these peripherals will be accessible only during HAL initialization
-    /// (between [`SystemHal::initialize`] and [`SystemHal::configure_hardware`] calls).
-    ///
     /// # Safety
-    /// This function should be only called once inside [`SystemHal::initialize`].
+    /// This function should be only called once inside [`Hal::initialize`].
     /// Subsequent calls will return valid peripherals, but it's not possible to
     /// guarantee safety if multiple instances of peripherals are used in the system.
     fn create_system_peripherals() -> SystemPeripherals {

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -128,7 +128,7 @@ impl SystemHal for Hal {
             // section is finished.
             let is_hal_created = unsafe { HAL_SYSTEM_PERIPHERALS.as_ref().is_some() };
             if is_hal_created {
-                return Err(HalError::HalAlreadyCreated);
+                return Err(HalError::HalAlreadyInitialized);
             }
 
             unsafe {
@@ -160,7 +160,7 @@ impl SystemHal for Hal {
             // of single-core MCU and no other references to peripherals should exist at this time.
             let is_hal_created = unsafe { HAL_SYSTEM_PERIPHERALS.as_ref().is_some() };
             if !is_hal_created {
-                return Err(HalError::HalNotCreated);
+                return Err(HalError::HalNotInitialized);
             }
 
             // SAFETY: Mutable access to system peripherals is safe, as we're in critical section
@@ -176,7 +176,7 @@ impl SystemHal for Hal {
             if peripherals.pmc.is_none() {
                 // If PMC is not available, it means that system has already been initialized,
                 // so this function cannot proceed.
-                return Err(HalError::SystemAlreadyInitialized);
+                return Err(HalError::HardwareAlreadyInitialized);
             }
             // This should realistically never panic, as we checked the existence of PMC earlier.
             let pmc = peripherals
@@ -190,7 +190,7 @@ impl SystemHal for Hal {
                 ..Default::default()
             }) {
                 Ok(()) => {}
-                Err(_) => return Err(HalError::SystemAlreadyInitialized),
+                Err(_) => return Err(HalError::HardwareAlreadyInitialized),
             };
 
             // Configure system timer

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -27,7 +27,7 @@ use pac::{self, PMC, TC0};
 static HAL_SYSTEM_PERIPHERALS: InternalCell<Option<SystemPeripherals>> = InternalCell::new(None);
 
 /// HAL implementation for Cortex-M based SAMV71 MCU.
-pub struct Hal {}
+pub struct Hal;
 
 impl Hal {
     /// Frequency of system timer.

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -63,11 +63,11 @@ impl Hal {
     /// This function steals PAC peripherals and returns a [`UserPeripherals`] structure
     /// containing all peripherals that are available to user via HAL drivers.
     ///
-    /// Some of these peripherals are taken from [`SystemPeripherals`] structure, hence
+    /// Some of these peripherals are taken from SystemPeripherals structure, hence
     /// this function should not be called before finishing HAL initialization (via
     /// [`SystemHal::configure_hardware] function).
     ///
-    /// This function executes in critical section, as it modifies [`HAL_SYSTEM_PERIPHERALS`].
+    /// This function executes in critical section, as it modifies HAL_SYSTEM_PERIPHERALS.
     ///
     /// # Safety
     /// This function can be called successfully only once, after HAL initialization.
@@ -112,7 +112,7 @@ impl SystemHal for Hal {
     /// by calling [`SystemHal::configure_hardware`]. Until then, no other HAL functions should
     /// be called, as they will most likely fail.
     ///
-    /// This function executes in critical section, as it modifies [`HAL_SYSTEM_PERIPHERALS`].
+    /// This function executes in critical section, as it modifies HAL_SYSTEM_PERIPHERALS.
     ///
     /// # Safety
     /// This function is safe to call only once.

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -75,16 +75,16 @@ impl Hal {
         })
     }
 
-    /// Create system peripherals of HAL.
+    /// Creates system peripherals of HAL.
     ///
     /// This function steals PAC peripherals and returns a [`SystemPeripherals`] structure
     /// containing peripherals used by [`SystemHal`] API implementation.
     ///
     /// Some of these peripherals will be accessible only during HAL initialization
-    /// (between [`Hal::create`] and [`SystemHal::configure_hardware`] calls).
+    /// (between [`SystemHal::initialize`] and [`SystemHal::configure_hardware`] calls).
     ///
     /// # Safety
-    /// This function should be only called once inside [`Hal::create`].
+    /// This function should be only called once inside [`SystemHal::initialize`].
     /// Subsequent calls will return valid peripherals, but it's not possible to
     /// guarantee safety if multiple instances of peripherals are used in the system.
     fn create_system_peripherals() -> SystemPeripherals {
@@ -106,7 +106,7 @@ impl SystemHal for Hal {
     type Duration = crate::time::TimerDurationU64<{ Hal::TIMER_FREQ }>;
     type Error = HalError;
 
-    /// Initialize global HAL instance using PAC peripherals.
+    /// Initializes global HAL instance using PAC peripherals.
     ///
     /// Calling this function begins HAL initialization process. This process must be finished
     /// by calling [`SystemHal::configure_hardware`]. Until then, no other HAL functions should
@@ -119,7 +119,7 @@ impl SystemHal for Hal {
     /// Subsequent calls will return an error, indicating that HAL instance has already been created.
     ///
     /// # Return
-    /// `()` on success, [`HalError::HalAlreadyCreated`] if called more than once.
+    /// `()` on success, [`HalError::HalAlreadyInitialized`] if called more than once.
     fn initialize() -> Result<(), HalError> {
         Hal::execute_critical(|_| {
             // SAFETY:
@@ -144,7 +144,7 @@ impl SystemHal for Hal {
     /// This function performs SAMV71 hardware configuration required for the HAL to work correctly.
     ///
     /// Calling this function finishes HAL initialization process. It should be called as soon as possible
-    /// after creating HAL instance via [`SystemHal::create`].
+    /// after creating HAL instance via [`SystemHal::initialize`].
     ///
     /// This function executes in critical section, as it modifies HAL_SYSTEM_PERIPHERALS.
     ///

--- a/arch/cortex-m/samv71-hal/src/hal.rs
+++ b/arch/cortex-m/samv71-hal/src/hal.rs
@@ -141,6 +141,19 @@ impl SystemHal for Hal {
         })
     }
 
+    /// This function performs SAMV71 hardware configuration required for the HAL to work correctly.
+    ///
+    /// Calling this function finishes HAL initialization process. It should be called as soon as possible
+    /// after creating HAL instance via [`SystemHal::create`].
+    ///
+    /// This function executes in critical section, as it modifies HAL_SYSTEM_PERIPHERALS.
+    ///
+    /// # Safety
+    /// This function is safe to call only once.
+    /// Subsequent calls will return an error, indicating that HAL instance has already been initialized.
+    ///
+    /// # Return
+    /// `()` on success, [`HalError`] if HAL is either not created yet, or were already initialized.
     fn configure_hardware(config: SystemHardwareConfig) -> Result<(), HalError> {
         Hal::execute_critical(|_| {
             // SAFETY: Immutable access to system peripherals is safe, as we're in critical section

--- a/arch/cortex-m/samv71-hal/src/system_peripherals.rs
+++ b/arch/cortex-m/samv71-hal/src/system_peripherals.rs
@@ -9,7 +9,7 @@ use crate::drivers::{
 
 /// System peripherals structure. These peripherals are represented as HAL drivers.
 /// Some of these peripherals are available only during HAL initialization
-/// (between [`Hal::create`] and [`SystemHal::configure_hardware`] calls).
+/// (between Hal::create and SystemHal::configure_hardware calls).
 pub struct SystemPeripherals {
     /// Watchdog instance.
     pub watchdog: Watchdog,

--- a/arch/cortex-m/samv71-hal/src/system_peripherals.rs
+++ b/arch/cortex-m/samv71-hal/src/system_peripherals.rs
@@ -8,7 +8,8 @@ use crate::drivers::{
 };
 
 /// System peripherals structure. These peripherals are represented as HAL drivers.
-/// They are initialized on system init, and used directly by HAL to provide core functionality.
+/// Some of these peripherals are available only during HAL initialization
+/// (between [`Hal::create`] and [`SystemHal::configure_hardware`] calls).
 pub struct SystemPeripherals {
     /// Watchdog instance.
     pub watchdog: Watchdog,

--- a/arch/cortex-m/samv71-hal/src/system_peripherals.rs
+++ b/arch/cortex-m/samv71-hal/src/system_peripherals.rs
@@ -9,7 +9,7 @@ use crate::drivers::{
 
 /// System peripherals structure. These peripherals are represented as HAL drivers.
 /// Some of these peripherals are available only during HAL initialization
-/// (between Hal::create and SystemHal::configure_hardware calls).
+/// (between `SystemHal::initialize` and `SystemHal::configure_hardware` calls).
 pub struct SystemPeripherals {
     /// Watchdog instance.
     pub watchdog: Watchdog,

--- a/arch/x86/x86-hal/src/hal.rs
+++ b/arch/x86/x86-hal/src/hal.rs
@@ -8,35 +8,21 @@ use bare_metal::CriticalSection;
 use once_cell::sync::Lazy;
 
 use crate::error::HalError;
-use crate::system_peripherals::SystemPeripherals;
 use crate::user_peripherals::UserPeripherals;
 
 /// Time when system was started
 static TIME_START: Lazy<SystemTime> = Lazy::new(SystemTime::now);
 
 /// HAL implementation for x86.
-pub struct Hal {
-    /// Hardware peripherals.
-    user_peripherals: Option<UserPeripherals>,
-    /// System peripherals.
-    _system_peripherals: Option<SystemPeripherals>,
-}
+pub struct Hal {}
 
 impl Hal {
     /// Frequency for the time types (TODO)
     const TIMER_FREQ: u32 = 1_000_000;
 
-    /// Create new HAL instance.
-    pub fn new() -> Result<Self, HalError> {
-        Ok(Hal {
-            user_peripherals: Some(UserPeripherals::default()),
-            _system_peripherals: Some(SystemPeripherals::default()),
-        })
-    }
-
-    /// Returns PAC peripherals for the user. Can be called successfully only once.
-    pub fn user_peripherals(&mut self) -> Option<UserPeripherals> {
-        self.user_peripherals.take()
+    /// Returns empty UserPeripherals struct, as x86 does not provide any.
+    pub fn create_user_peripherals() -> Option<UserPeripherals> {
+        Some(UserPeripherals {})
     }
 }
 
@@ -45,12 +31,17 @@ impl SystemHal for Hal {
     type Duration = crate::time::TimerDurationU64<{ Hal::TIMER_FREQ }>;
     type Error = HalError;
 
-    fn configure_hardware(&mut self, _config: SystemHardwareConfig) -> Result<(), HalError> {
+    fn create() -> Result<(), Self::Error> {
+        // There's nothing to create on x86
+        Ok(())
+    }
+
+    fn configure_hardware(_config: SystemHardwareConfig) -> Result<(), HalError> {
         // There is no hardware to configure on x86
         Ok(())
     }
 
-    fn get_system_time(&self) -> Self::Instant {
+    fn get_system_time() -> Self::Instant {
         Self::Instant::from_ticks(
             TIME_START
                 .elapsed()
@@ -61,7 +52,7 @@ impl SystemHal for Hal {
         )
     }
 
-    fn feed_watchdog(&mut self) {
+    fn feed_watchdog() {
         // There is no watchdog for x86 target.
     }
 

--- a/arch/x86/x86-hal/src/hal.rs
+++ b/arch/x86/x86-hal/src/hal.rs
@@ -31,11 +31,6 @@ impl SystemHal for Hal {
     type Duration = crate::time::TimerDurationU64<{ Hal::TIMER_FREQ }>;
     type Error = HalError;
 
-    fn initialize() -> Result<(), Self::Error> {
-        // There's nothing to create on x86
-        Ok(())
-    }
-
     fn configure_hardware(_config: SystemHardwareConfig) -> Result<(), HalError> {
         // There is no hardware to configure on x86
         Ok(())

--- a/arch/x86/x86-hal/src/hal.rs
+++ b/arch/x86/x86-hal/src/hal.rs
@@ -31,7 +31,7 @@ impl SystemHal for Hal {
     type Duration = crate::time::TimerDurationU64<{ Hal::TIMER_FREQ }>;
     type Error = HalError;
 
-    fn create() -> Result<(), Self::Error> {
+    fn initialize() -> Result<(), Self::Error> {
         // There's nothing to create on x86
         Ok(())
     }

--- a/examples/samv71-hal-timer/src/main.rs
+++ b/examples/samv71-hal-timer/src/main.rs
@@ -107,16 +107,11 @@ fn main() -> ! {
 
     rprintln!("Hello, world! Initializing Aerugo...");
 
-    AERUGO.initialize(SystemHardwareConfig {
+    let peripherals = AERUGO.initialize(SystemHardwareConfig {
         watchdog_timeout: MillisDurationU32::secs(5),
     });
 
     rprintln!("Doing stuff with timers...");
-    let peripherals = AERUGO
-        .peripherals()
-        .expect("peripherals are not initialized")
-        .expect("peripherals already taken");
-
     let mut timer = Timer::new(peripherals.timer_counter1.expect("Timer 1 already used"));
     // TODO: Change this to use proper PMC driver when it's done
     let pmc = peripherals.pmc.expect("PMC already used");

--- a/src/aerugo.rs
+++ b/src/aerugo.rs
@@ -66,8 +66,8 @@ impl Aerugo {
 
     /// Initialize the system runtime and hardware.
     pub fn initialize(&'static self, config: SystemHardwareConfig) -> UserPeripherals {
-        Hal::initialize().expect("HAL initialization failed");
-        Hal::configure_hardware(config).expect("Hardware configuration failed");
+        Hal::configure_hardware(config)
+            .expect("HAL initialization or hardware configuration failed");
         Hal::create_user_peripherals().expect("Cannot create user peripherals instance")
     }
 

--- a/src/aerugo.rs
+++ b/src/aerugo.rs
@@ -66,7 +66,7 @@ impl Aerugo {
 
     /// Initialize the system runtime and hardware.
     pub fn initialize(&'static self, config: SystemHardwareConfig) -> UserPeripherals {
-        Hal::create().expect("HAL initialization failed");
+        Hal::initialize().expect("HAL initialization failed");
         Hal::configure_hardware(config).expect("Hardware configuration failed");
         Hal::create_user_peripherals().expect("Cannot create user peripherals instance")
     }

--- a/src/aerugo.rs
+++ b/src/aerugo.rs
@@ -49,7 +49,7 @@ static TIME_MANAGER: TimeManager = TimeManager::new();
 /// This shouldn't be created by hand by the user or anywhere else in the code.
 /// It should be used as a [singleton](crate::aerugo::AERUGO) that acts as a system API,
 /// both for user and for the internal system parts.
-pub struct Aerugo {}
+pub struct Aerugo;
 
 impl Aerugo {
     /// Maximum number of tasklets registered in the system.

--- a/testbins/test-hal-timer/src/main.rs
+++ b/testbins/test-hal-timer/src/main.rs
@@ -152,14 +152,9 @@ fn get_irq_count() -> u32 {
 fn main() -> ! {
     calldwell::start_test_session();
 
-    AERUGO.initialize(SystemHardwareConfig {
+    let peripherals = AERUGO.initialize(SystemHardwareConfig {
         watchdog_timeout: MillisDurationU32::secs(3),
     });
-
-    let peripherals = AERUGO
-        .peripherals()
-        .expect("HAL was not initialized!")
-        .expect("Peripherals already taken!");
 
     let timer = Timer::new(peripherals.timer_counter1.expect("TC1 already taken!"));
 


### PR DESCRIPTION
Refactored internal code of HAL initialization, moved peripherals to global HAL instance, changed `SystemHal` API to stateless one.