### PR TITLE
ROS#151 - Logging for Cortex-M and log improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,12 @@ test-binary = "3.0"
 assert_cmd = "2.0"
 
 [features]
+default = ["log"]
 use-aerugo-cortex-m = ["aerugo-cortex-m", "samv71-hal"]
 use-aerugo-x86 = ["aerugo-x86", "x86-hal"]
 test-aerugo-cortex-m = ["use-aerugo-x86"]
 rt = ["samv71-hal?/rt"]
+log = ["aerugo-cortex-m?/log", "aerugo-x86?/log"]
 
 [profile.release]
 codegen-units = 1

--- a/arch/cortex-m/aerugo-cortex-m/Cargo.toml
+++ b/arch/cortex-m/aerugo-cortex-m/Cargo.toml
@@ -11,4 +11,7 @@ description = "Cortex-M specific implementation for Aerugo"
 
 [dependencies]
 cortex-m = "0.7.7"
-cortex-m-semihosting = "0.5.0"
+rtt-target = "0.4.0"
+
+[features]
+log = []

--- a/arch/cortex-m/aerugo-cortex-m/src/lib.rs
+++ b/arch/cortex-m/aerugo-cortex-m/src/lib.rs
@@ -6,8 +6,10 @@ Cortex-M specific implementation for Aerugo.
 #![warn(clippy::missing_docs_in_private_items)]
 #![warn(rustdoc::missing_crate_level_docs)]
 
+#[cfg(feature = "log")]
 mod logger;
 mod mutex;
 
-pub use self::logger::log;
+#[cfg(feature = "log")]
+pub use self::logger::{init_log, log, logln};
 pub use self::mutex::Mutex;

--- a/arch/cortex-m/aerugo-cortex-m/src/logger.rs
+++ b/arch/cortex-m/aerugo-cortex-m/src/logger.rs
@@ -1,3 +1,19 @@
 //! Simple logging utility for the x86 target.
 
-pub use cortex_m_semihosting::hprintln as log;
+/// Alias for `log!` macro, which prints a message.
+///
+/// <div class="warning">Missing newline may prevent "flushing" the RTT, try using `logln!`
+/// when output is not being flushed correctly!</div>
+///
+/// <div class="warning">Call `Aerugo::initialize` before using this function!</div>
+pub use rtt_target::rprint as log;
+/// Alias for `logln!` macro, which prints a message and adds newline at the end.
+///
+/// <div class="warning">Call `Aerugo::initialize` before using this function!</div>
+pub use rtt_target::rprintln as logln;
+
+/// Function used to initialize logging facilities. Should be called once, on init.
+#[inline(never)]
+pub fn init_log() {
+    rtt_target::rtt_init_print!();
+}

--- a/arch/x86/aerugo-x86/Cargo.toml
+++ b/arch/x86/aerugo-x86/Cargo.toml
@@ -11,3 +11,6 @@ description = "x86 specific implementation for Aerugo"
 
 [dependencies]
 aerugo-hal = { version = "0.1.0", path = "../../../aerugo-hal" }
+
+[features]
+log = []

--- a/arch/x86/aerugo-x86/src/lib.rs
+++ b/arch/x86/aerugo-x86/src/lib.rs
@@ -5,8 +5,10 @@ x86 specific implementation for Aerugo.
 #![warn(clippy::missing_docs_in_private_items)]
 #![warn(rustdoc::missing_crate_level_docs)]
 
+#[cfg(feature = "log")]
 mod logger;
 mod mutex;
 
-pub use self::logger::log;
+#[cfg(feature = "log")]
+pub use self::logger::{init_log, log, logln};
 pub use self::mutex::Mutex;

--- a/arch/x86/aerugo-x86/src/logger.rs
+++ b/arch/x86/aerugo-x86/src/logger.rs
@@ -1,3 +1,11 @@
 //! Simple logging utility for the x86 target.
 
-pub use std::println as log;
+/// Alias for `log!` macro, which prints a message.
+pub use std::print as log;
+/// Alias for `logln!` macro, which prints a message and adds newline at the end.
+pub use std::println as logln;
+
+/// Function used to initialize logging facilities. Should be called once, on init.
+pub fn init_log() {
+    // No-op on x86
+}

--- a/calldwell/__init__.py
+++ b/calldwell/__init__.py
@@ -1,0 +1,7 @@
+import logging
+
+
+def init_default_logger():
+    logging.basicConfig(
+        level=logging.INFO, format="[%(asctime)s] <%(levelname)s|%(name)s>: %(message)s"
+    )

--- a/calldwell/examples/unit_test_app/__main__.py
+++ b/calldwell/examples/unit_test_app/__main__.py
@@ -3,6 +3,7 @@ import os
 import sys
 from pathlib import Path
 
+from calldwell import init_default_logger
 from calldwell.rust_helpers import build_cargo_app, init_remote_calldwell_rs_session
 from calldwell.ssh_client import SSHClient
 
@@ -75,5 +76,5 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    init_default_logger()
     main()

--- a/calldwell/scripts/check_code.sh
+++ b/calldwell/scripts/check_code.sh
@@ -2,11 +2,13 @@
 
 set -euo pipefail
 
+echo "Checking ./*.py"
 poetry run isort --check ./*.py
 poetry run black --check ./*.py
 poetry run flake8 ./*.py
 poetry run mypy ./*.py
 
+echo "Checking ./examples/**/*.py"
 poetry run isort --check ./examples/**/*.py
 poetry run black --check ./examples/**/*.py
 poetry run flake8 ./examples/**/*.py

--- a/calldwell/scripts/format_code.sh
+++ b/calldwell/scripts/format_code.sh
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
+echo "Formatting ./*.py"
 poetry run isort ./*.py
-poetry run isort ./examples/**/*.py
 poetry run black ./*.py
+
+echo "Formatting ./examples/**/*.py"
 poetry run black ./examples/**/*.py
+poetry run isort ./examples/**/*.py

--- a/examples/samv71-basic-execution/.vscode/launch.json.example
+++ b/examples/samv71-basic-execution/.vscode/launch.json.example
@@ -13,13 +13,15 @@
             "request": "launch",
             "type": "cortex-debug",
             "runToEntryPoint": "main",
-            "servertype": "external", // Change this is your devboard is not remotely accessible
+            "servertype": "external", // Change this is your devboard is locally accessible
             "device": "samv71q21",
             "gdbTarget": "PUT IP:PORT OF REMOTE OPENOCD INSTANCE HERE",
             "svdPath": "${workspaceFolder}/arch/cortex-m/samv71q21-pac/ATSAMV71Q21B.svd",
             "postLaunchCommands": [
+                "set remotetimeout 10",
                 "set print asm-demangle on",
-                "monitor arm semihosting enable",
+                "monitor rtt setup 0x20400000 0x400 \"SEGGER RTT\"",
+                "monitor rtt server start 7897 0",
             ],
         },
     ]

--- a/examples/samv71-basic-execution/Cargo.toml
+++ b/examples/samv71-basic-execution/Cargo.toml
@@ -13,7 +13,6 @@ aerugo = { version = "0.1.0", path = "../..", features = [
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
-rtt-target = "0.4.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/samv71-basic-execution/src/main.rs
+++ b/examples/samv71-basic-execution/src/main.rs
@@ -4,14 +4,12 @@
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
 extern crate panic_rtt_target;
-extern crate rtt_target as rtt;
 
 use aerugo::{
-    time::MillisDurationU32, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig,
+    logln, time::MillisDurationU32, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig,
     TaskletStorage, AERUGO,
 };
 use rt::entry;
-use rtt::rprintln;
 
 #[derive(Default)]
 struct DummyTaskContext {
@@ -21,7 +19,7 @@ struct DummyTaskContext {
 fn dummy_task(_: (), context: &mut DummyTaskContext, _: &dyn RuntimeApi) {
     context.acc = context.acc.wrapping_add(1);
     if context.acc % 250 == 0 {
-        rprintln!("I'm running!");
+        logln!("I'm running!");
     }
 }
 
@@ -29,16 +27,14 @@ static DUMMY_TASK_STORAGE: TaskletStorage<(), DummyTaskContext, 0> = TaskletStor
 
 #[entry]
 fn main() -> ! {
-    init_rtt();
-
-    rprintln!("Hello, world! Initializing Aerugo...");
-
     AERUGO.initialize(SystemHardwareConfig {
         watchdog_timeout: MillisDurationU32::secs(5),
         ..Default::default()
     });
 
-    rprintln!("Creating tasks...");
+    logln!("Hello, world! Aerugo initialized!");
+
+    logln!("Creating tasks...");
     let dummy_task_config = TaskletConfig {
         name: "DummyTask",
         ..Default::default()
@@ -58,18 +54,13 @@ fn main() -> ! {
         .create_handle()
         .expect("Unable to create handle to dummy task!");
 
-    rprintln!("Subscribing tasks...");
+    logln!("Subscribing tasks...");
 
     AERUGO
         .subscribe_tasklet_to_cyclic(&dummy_task_handle, None)
         .expect("Unable to subscribe dummy task to cyclic execution!");
 
-    rprintln!("Starting the system!");
+    logln!("Starting the system!");
 
     AERUGO.start();
-}
-
-#[inline(never)]
-fn init_rtt() {
-    rtt::rtt_init_print!();
 }

--- a/examples/samv71-fizz-buzz/Cargo.toml
+++ b/examples/samv71-fizz-buzz/Cargo.toml
@@ -16,7 +16,6 @@ aerugo = { version = "0.1.0", path = "../..", features = [
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
-rtt-target = "0.4.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/samv71-hal-timer/Cargo.toml
+++ b/examples/samv71-hal-timer/Cargo.toml
@@ -14,7 +14,6 @@ aerugo = { version = "0.1.0", path = "../..", features = [
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.3", features = ["device"] }
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
-rtt-target = "0.4.0"
 
 [features]
 rt = ["aerugo/rt"]

--- a/examples/samv71-system-time/Cargo.toml
+++ b/examples/samv71-system-time/Cargo.toml
@@ -13,7 +13,6 @@ aerugo = { version = "0.1.0", path = "../..", features = [
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
-rtt-target = "0.4.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/samv71-system-time/src/main.rs
+++ b/examples/samv71-system-time/src/main.rs
@@ -4,14 +4,12 @@
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
 extern crate panic_rtt_target;
-extern crate rtt_target as rtt;
 
 use aerugo::{
-    time::MillisDurationU32, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig,
+    logln, time::MillisDurationU32, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig,
     TaskletStorage, AERUGO,
 };
 use rt::entry;
-use rtt::rprintln;
 
 #[derive(Default)]
 struct DummyTaskContext {
@@ -24,7 +22,7 @@ fn dummy_task(_: (), context: &mut DummyTaskContext, api: &'static dyn RuntimeAp
         let time = api.get_system_time().duration_since_epoch();
         let time_seconds = time.to_secs();
         let time_millis = time.to_millis() % 1000;
-        rprintln!("Current time is {}s {}ms", time_seconds, time_millis);
+        logln!("Current time is {}s {}ms", time_seconds, time_millis);
     }
 }
 
@@ -32,16 +30,14 @@ static DUMMY_TASK_STORAGE: TaskletStorage<(), DummyTaskContext, 0> = TaskletStor
 
 #[entry]
 fn main() -> ! {
-    init_rtt();
-
-    rprintln!("Hello, world! Initializing Aerugo...");
-
     AERUGO.initialize(SystemHardwareConfig {
         watchdog_timeout: MillisDurationU32::secs(5),
         ..Default::default()
     });
 
-    rprintln!("Creating tasks...");
+    logln!("Hello, world! Aerugo initialized!");
+
+    logln!("Creating tasks...");
     let dummy_task_config = TaskletConfig {
         name: "DummyTask",
         ..Default::default()
@@ -61,18 +57,13 @@ fn main() -> ! {
         .create_handle()
         .expect("Unable to create handle to dummy task!");
 
-    rprintln!("Subscribing tasks...");
+    logln!("Subscribing tasks...");
 
     AERUGO
         .subscribe_tasklet_to_cyclic(&dummy_task_handle, None)
         .expect("Unable to subscribe dummy task to cyclic execution!");
 
-    rprintln!("Starting the system!");
+    logln!("Starting the system!");
 
     AERUGO.start();
-}
-
-#[inline(never)]
-fn init_rtt() {
-    rtt::rtt_init_print!();
 }

--- a/examples/x86-basic-execution/src/main.rs
+++ b/examples/x86-basic-execution/src/main.rs
@@ -1,5 +1,5 @@
 use aerugo::{
-    log, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage, AERUGO,
+    logln, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage, AERUGO,
 };
 
 #[derive(Default)]
@@ -9,7 +9,7 @@ struct TaskAContext {
 
 fn task_a(_: (), context: &mut TaskAContext, _: &dyn RuntimeApi) {
     context.acc = context.acc.wrapping_add(1);
-    log!("TaskA: {}", context.acc);
+    logln!("TaskA: {}", context.acc);
 }
 
 #[derive(Default)]
@@ -19,7 +19,7 @@ struct TaskBContext {
 
 fn task_b(_: (), context: &mut TaskBContext, _: &dyn RuntimeApi) {
     context.acc = context.acc.wrapping_add(2);
-    log!("TaskB: {}", context.acc);
+    logln!("TaskB: {}", context.acc);
 }
 
 static TASK_A_STORAGE: TaskletStorage<(), TaskAContext, 0> = TaskletStorage::new();

--- a/examples/x86-boolean-condition/src/main.rs
+++ b/examples/x86-boolean-condition/src/main.rs
@@ -1,5 +1,5 @@
 use aerugo::{
-    log, BooleanConditionHandle, BooleanConditionSet, BooleanConditionStorage, InitApi,
+    logln, BooleanConditionHandle, BooleanConditionSet, BooleanConditionStorage, InitApi,
     MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig, TaskletConfig,
     TaskletStorage, AERUGO,
 };
@@ -23,7 +23,7 @@ fn task_a(_: (), context: &mut TaskAContext, _: &dyn RuntimeApi) {
 
 #[allow(clippy::needless_pass_by_ref_mut)]
 fn task_b(data: u8, context: &mut TaskBContext, _: &dyn RuntimeApi) {
-    log!("TaskB: {}", data);
+    logln!("TaskB: {}", data);
 
     context.counter += 1;
 

--- a/examples/x86-events/src/main.rs
+++ b/examples/x86-events/src/main.rs
@@ -1,5 +1,6 @@
 use aerugo::{
-    log, EventId, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage, AERUGO,
+    logln, EventId, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage,
+    AERUGO,
 };
 
 enum MyEvents {
@@ -44,14 +45,14 @@ fn task_a(_: (), context: &mut TaskAContext, api: &'static dyn RuntimeApi) {
 struct TaskBContext {}
 
 fn task_b(value: EventId, _: &mut TaskBContext, _: &'static dyn RuntimeApi) {
-    log!("TaskB: {}", value);
+    logln!("TaskB: {}", value);
 }
 
 #[derive(Default)]
 struct TaskCContext {}
 
 fn task_c(value: EventId, _: &mut TaskCContext, _: &'static dyn RuntimeApi) {
-    log!("TaskC: {}", value);
+    logln!("TaskC: {}", value);
 }
 
 static TASK_A_STORAGE: TaskletStorage<(), TaskAContext, 0> = TaskletStorage::new();

--- a/examples/x86-fizz-buzz/src/main.rs
+++ b/examples/x86-fizz-buzz/src/main.rs
@@ -1,7 +1,7 @@
 use aerugo::{
-    log, BooleanConditionHandle, BooleanConditionSet, BooleanConditionStorage, EventId, InitApi,
-    MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig, TaskletConfig,
-    TaskletStorage, AERUGO,
+    log, logln, BooleanConditionHandle, BooleanConditionSet, BooleanConditionStorage, EventId,
+    InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
+    TaskletConfig, TaskletStorage, AERUGO,
 };
 
 struct ProducerContext {
@@ -37,7 +37,7 @@ fn distributor(val: u8, _: &mut DistributorContext, api: &'static dyn RuntimeApi
         (_, 0) => api
             .emit_event(FizzBuzzEvents::Buzz.into())
             .expect("Failed to emit Buzz"),
-        _ => log!("{}\n", val),
+        _ => logln!("{}", val),
     }
 }
 
@@ -48,7 +48,7 @@ fn fizz(val: EventId, _: &mut FizzContext, _: &'static dyn RuntimeApi) {
     log!("Fizz");
 
     if let FizzBuzzEvents::Fizz = val.into() {
-        log!("\n");
+        logln!();
     }
 }
 
@@ -56,14 +56,14 @@ fn fizz(val: EventId, _: &mut FizzContext, _: &'static dyn RuntimeApi) {
 struct BuzzContext {}
 
 fn buzz(_: EventId, _: &mut BuzzContext, _: &'static dyn RuntimeApi) {
-    log!("Buzz\n");
+    logln!("Buzz");
 }
 
 #[derive(Default)]
 struct DoneContext {}
 
 fn done(_: bool, _: &mut DoneContext, _: &'static dyn RuntimeApi) {
-    log!("Done!\n");
+    logln!("Done!");
 
     std::process::exit(0);
 }

--- a/examples/x86-message-queue/src/main.rs
+++ b/examples/x86-message-queue/src/main.rs
@@ -1,5 +1,5 @@
 use aerugo::{
-    log, InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
+    logln, InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
     TaskletConfig, TaskletStorage, AERUGO,
 };
 
@@ -13,7 +13,7 @@ struct TaskBContext {
 
 #[allow(clippy::needless_pass_by_ref_mut)]
 fn task_a(data: u8, context: &mut TaskAContext, _: &dyn RuntimeApi) {
-    log!("TaskA: {}", data);
+    logln!("TaskA: {}", data);
     context
         .queue_handle
         .send_data(data.wrapping_add(1))
@@ -22,7 +22,7 @@ fn task_a(data: u8, context: &mut TaskAContext, _: &dyn RuntimeApi) {
 
 #[allow(clippy::needless_pass_by_ref_mut)]
 fn task_b(data: u8, context: &mut TaskBContext, _: &dyn RuntimeApi) {
-    log!("TaskB: {}", data);
+    logln!("TaskB: {}", data);
     context
         .queue_handle
         .send_data(data.wrapping_add(1))

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,18 +3,22 @@
 set -euo pipefail
 
 aerugo_x86_debug() {
+    echo "Building Aerugo (x86, debug)"
     cargo build --features=use-aerugo-x86 --target=x86_64-unknown-linux-gnu --package aerugo
 }
 
 aerugo_x86_release() {
+    echo "Building Aerugo (x86, release)"
     cargo build --release --features=use-aerugo-x86 --target=x86_64-unknown-linux-gnu --package aerugo
 }
 
 aerugo_cm7_debug() {
+    echo "Building Aerugo (Cortex-M, debug)"
     cargo build --features=use-aerugo-cortex-m --target=thumbv7em-none-eabihf --package aerugo
 }
 
 aerugo_cm7_release() {
+    echo "Building Aerugo (Cortex-M, release)"
     cargo build --release --features=use-aerugo-cortex-m --target=thumbv7em-none-eabihf --package aerugo
 }
 

--- a/scripts/build_examples.sh
+++ b/scripts/build_examples.sh
@@ -2,15 +2,16 @@
 
 set -euo pipefail
 
-if [ $# -eq 0 ]
-then
+if [ $# -eq 0 ]; then
     for d in examples/*/; do
         pushd $d > /dev/null
+        echo "Building $d"
         cargo build
         popd > /dev/null
     done
 else
     pushd examples/$1/ > /dev/null
+    echo "Building examples/$1/"
     cargo build
     popd > /dev/null
 fi

--- a/scripts/build_hal_tests.sh
+++ b/scripts/build_hal_tests.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 for d in testbins/test-hal-*/; do
   pushd $d > /dev/null
+  echo "Building $d"
   cargo build
   popd > /dev/null
 done

--- a/scripts/check_code.sh
+++ b/scripts/check_code.sh
@@ -7,6 +7,7 @@ cargo clippy --workspace --tests -F use-aerugo-cortex-m -- -D warnings
 for d in examples/*/; do
     pushd $d >/dev/null
     if [[ -f "Cargo.toml" ]]; then
+        echo "Checking code: $d"
         cargo clippy -- -D warnings
     fi
     popd >/dev/null
@@ -15,6 +16,7 @@ done
 for d in testbins/*/; do
     pushd $d >/dev/null
     if [[ -f "Cargo.toml" ]]; then
+        echo "Checking code: $d"
         cargo clippy -- -D warnings
     fi
     popd >/dev/null

--- a/scripts/check_fmt.sh
+++ b/scripts/check_fmt.sh
@@ -7,6 +7,7 @@ cargo fmt -- --check --color always
 for d in examples/*/; do
     pushd $d >/dev/null
     if [[ -f "Cargo.toml" ]]; then
+        echo "Checking formatting: $d"
         cargo fmt -- --check --color always
     fi
     popd >/dev/null
@@ -15,6 +16,7 @@ done
 for d in testbins/*/; do
     pushd $d >/dev/null
     if [[ -f "Cargo.toml" ]]; then
+        echo "Checking formatting: $d"
         cargo fmt -- --check --color always
     fi
     popd >/dev/null

--- a/scripts/check_python_code.sh
+++ b/scripts/check_python_code.sh
@@ -2,11 +2,13 @@
 
 set -euo pipefail
 
+echo "Checking test/requirements/test/*.py"
 poetry run isort --check tests/requirements/test/*.py
 poetry run black --check tests/requirements/test/*.py
 poetry run flake8 tests/requirements/test/*.py
 poetry run mypy tests/requirements/test/*.py
 
+echo "Checking scripts/*.py"
 poetry run isort --check scripts/*.py
 poetry run black --check scripts/*.py
 poetry run flake8 scripts/*.py

--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -6,12 +6,14 @@ cargo fmt
 
 for d in examples/*/; do
     pushd $d > /dev/null
+    echo "Formatting $d"
     cargo fmt
     popd > /dev/null
 done
 
 for d in testbins/*/; do
     pushd $d > /dev/null
+    echo "Formatting $d"
     cargo fmt
     popd > /dev/null
 done

--- a/scripts/format_python_code.sh
+++ b/scripts/format_python_code.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
+echo "Formatting tests/requirements/test/*.py"
 poetry run isort tests/requirements/test/*.py
 poetry run black tests/requirements/test/*.py
 
+echo "Formatting scripts/*.py"
 poetry run isort scripts/*.py
 poetry run black scripts/*.py

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -2,4 +2,5 @@
 
 set -euo pipefail
 
+echo "Generating documentation"
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items -F use-aerugo-cortex-m $@

--- a/scripts/generate_req_docs.sh
+++ b/scripts/generate_req_docs.sh
@@ -2,5 +2,6 @@
 
 set -euo pipefail
 
+echo "Generating requirements documentation"
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items -F use-aerugo-cortex-m --target-dir docs
 RUSTDOCFLAGS="-D warnings" cargo rustdoc --test requirement_tests -F use-aerugo-cortex-m --target-dir docs-test -- --document-private-items

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,6 +6,7 @@ aerugo_x86() {
     export AERUGO_TASKLET_COUNT=5
     export AERUGO_EVENT_COUNT=3
 
+    echo "Running x86 tests"
     cargo test --features=use-aerugo-x86 --target=x86_64-unknown-linux-gnu --package aerugo
 
     export -n AERUGO_EVENT_COUNT
@@ -16,6 +17,7 @@ aerugo_v71() {
     export AERUGO_TASKLET_COUNT=5
     export AERUGO_EVENT_COUNT=3
 
+    echo "Running HAL tests"
     cargo test --features=test-aerugo-cortex-m --target=x86_64-unknown-linux-gnu --package aerugo test_hal -- --test-threads=1
 
     export -n AERUGO_EVENT_COUNT
@@ -26,6 +28,7 @@ env_parser() {
     export ENV_PARSER_TEST_INTEGER_OVERRIDE=42
     export ENV_PARSER_TEST_INTEGER_DIFFERENT_NAME=314
 
+    echo "Running env_parser tests"
     cargo test --package env-parser-tests
 
     export -n ENV_PARSER_TEST_INTEGER_OVERRIDE
@@ -40,6 +43,7 @@ all() {
 
     # This is not simply a call to functions above, as it would produce two test outputs (with some tests ignored in one).
     # This will run all the tests using single runner, and generate a single test report.
+    echo "Running all tests"
     cargo test --features=test-aerugo-cortex-m --target=x86_64-unknown-linux-gnu --workspace -- --test-threads=1
 
     export -n AERUGO_EVENT_COUNT

--- a/scripts/run_v71_example.py
+++ b/scripts/run_v71_example.py
@@ -1,9 +1,9 @@
-import logging
 import sys
 from enum import IntEnum
 from pathlib import Path
 from typing import Tuple
 
+from calldwell import init_default_logger
 from calldwell.gdb_client import GDBClient
 from calldwell.rtt_client import RTTClient
 from calldwell.rust_helpers import (
@@ -164,5 +164,5 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    init_default_logger()
     main()

--- a/scripts/run_v71_example.py
+++ b/scripts/run_v71_example.py
@@ -24,7 +24,7 @@ from tests.requirements.test.test_utils import (
 
 # This script should be run from project's root dir, not from `scripts/`!
 EXAMPLES_DIR_PATH = Path("./examples")
-RTT_INIT_FUNCTION_NAME = "init_rtt"
+RTT_INIT_FUNCTION_NAME = "aerugo_cortex_m::logger::init_log"
 TARGET_TRIPLE = "thumbv7em-none-eabihf"
 
 
@@ -90,7 +90,7 @@ def load_and_start_program(gdb: GDBClient, program_path: Path):
 
 
 def wait_for_rtt_init(gdb: GDBClient, example_name: str):
-    rtt_init_function_full_name = f"{example_name.replace('-', '_')}::{RTT_INIT_FUNCTION_NAME}"
+    rtt_init_function_full_name = RTT_INIT_FUNCTION_NAME
 
     if not gdb.set_breakpoint(rtt_init_function_full_name):
         print(

--- a/src/aerugo.rs
+++ b/src/aerugo.rs
@@ -10,6 +10,8 @@ use bare_metal::CriticalSection;
 use env_parser::read_env;
 
 use crate::api::{InitApi, InitError, RuntimeApi, RuntimeError, SystemApi};
+#[cfg(feature = "log")]
+use crate::arch::init_log;
 use crate::boolean_condition::{
     BooleanConditionHandle, BooleanConditionSet, BooleanConditionStorage,
 };
@@ -65,6 +67,8 @@ impl Aerugo {
 
     /// Initialize the system runtime and hardware.
     pub fn initialize(&'static self, config: SystemHardwareConfig) -> UserPeripherals {
+        #[cfg(feature = "log")]
+        init_log();
         Hal::configure_hardware(config)
             .expect("HAL initialization or hardware configuration failed");
         Hal::create_user_peripherals().expect("Cannot create user peripherals instance")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,4 +44,5 @@ pub(crate) use aerugo_x86 as arch;
 #[cfg(feature = "use-aerugo-x86")]
 pub use x86_hal as hal;
 
-pub use arch::log;
+#[cfg(feature = "log")]
+pub use arch::{log, logln};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod event_manager;
 mod execution_monitoring;
 mod executor;
 mod message_queue;
+mod stubs;
 mod tasklet;
 mod time_manager;
 

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -1,0 +1,16 @@
+//! Module containing stubs with generic implementations of optional functions
+
+/// No-op `log` that replaces the actual implementation when `log` feature is disabled
+#[macro_export]
+#[cfg(not(feature = "log"))]
+macro_rules! log {
+    ($($arg:tt)*) => {{}};
+}
+
+/// No-op `logln` that replaces the actual implementation when `log` feature is disabled
+#[macro_export]
+#[cfg(not(feature = "log"))]
+macro_rules! logln {
+    () => {};
+    ($($arg:tt)*) => {{}};
+}

--- a/testbins/test-basic-execution/src/main.rs
+++ b/testbins/test-basic-execution/src/main.rs
@@ -1,5 +1,5 @@
 use aerugo::{
-    log, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage, AERUGO,
+    logln, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage, AERUGO,
 };
 
 #[derive(Default)]
@@ -9,7 +9,7 @@ struct TaskAContext {
 
 fn task_a(_: (), context: &mut TaskAContext, _: &dyn RuntimeApi) {
     if context.cnt < 2 {
-        log!("TaskA");
+        logln!("TaskA");
         context.cnt += 1;
     } else {
         std::process::exit(0);
@@ -23,7 +23,7 @@ struct TaskBContext {
 
 fn task_b(_: (), context: &mut TaskBContext, _: &dyn RuntimeApi) {
     if context.cnt < 2 {
-        log!("TaskB");
+        logln!("TaskB");
         context.cnt += 1;
     } else {
         std::process::exit(0);

--- a/testbins/test-boolean-condition/src/main.rs
+++ b/testbins/test-boolean-condition/src/main.rs
@@ -1,5 +1,5 @@
 use aerugo::{
-    log, BooleanConditionHandle, BooleanConditionSet, BooleanConditionStorage, InitApi,
+    logln, BooleanConditionHandle, BooleanConditionSet, BooleanConditionStorage, InitApi,
     MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig, TaskletConfig,
     TaskletStorage, AERUGO,
 };
@@ -26,7 +26,7 @@ fn task_a(_: (), context: &mut TaskAContext, _: &dyn RuntimeApi) {
     let enable_status = context.enable_condition_handle.get_value();
     let done_status = context.done_condition_handle.get_value();
 
-    log!("TaskA: {}, {}", enable_status, done_status);
+    logln!("TaskA: {}, {}", enable_status, done_status);
 
     context
         .queue_handle
@@ -36,7 +36,7 @@ fn task_a(_: (), context: &mut TaskAContext, _: &dyn RuntimeApi) {
 
 #[allow(clippy::needless_pass_by_ref_mut)]
 fn task_b(data: u8, context: &mut TaskBContext, _: &dyn RuntimeApi) {
-    log!("TaskB: {}", data);
+    logln!("TaskB: {}", data);
 
     context.counter += 1;
 
@@ -51,7 +51,7 @@ fn task_c(data: bool, context: &mut TaskCContext, _: &dyn RuntimeApi) {
     let enable_status = context.enable_condition_handle.get_value();
     let done_status = context.done_condition_handle.get_value();
 
-    log!("TaskC: {}, {}", enable_status, done_status);
+    logln!("TaskC: {}, {}", enable_status, done_status);
 
     if data {
         std::process::exit(0)

--- a/testbins/test-event-cancellation/src/main.rs
+++ b/testbins/test-event-cancellation/src/main.rs
@@ -1,5 +1,6 @@
 use aerugo::{
-    log, EventId, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage, AERUGO,
+    logln, EventId, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage,
+    AERUGO,
 };
 
 enum MyEvents {
@@ -48,14 +49,14 @@ fn task_a(_: (), context: &mut TaskAContext, api: &'static dyn RuntimeApi) {
 struct TaskBContext {}
 
 fn task_b(value: EventId, _: &mut TaskBContext, _: &'static dyn RuntimeApi) {
-    log!("TaskB: {}", value);
+    logln!("TaskB: {}", value);
 }
 
 #[derive(Default)]
 struct TaskCContext {}
 
 fn task_c(value: EventId, _: &mut TaskCContext, api: &'static dyn RuntimeApi) {
-    log!("TaskC: {}", value);
+    logln!("TaskC: {}", value);
     api.cancel_event(MyEvents::Event42.into())
         .expect("Failed to cancel Event42");
 }

--- a/testbins/test-event-clear-queue/src/main.rs
+++ b/testbins/test-event-clear-queue/src/main.rs
@@ -1,5 +1,6 @@
 use aerugo::{
-    log, EventId, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage, AERUGO,
+    logln, EventId, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage,
+    AERUGO,
 };
 
 enum MyEvents {
@@ -39,7 +40,7 @@ fn task_a(_: (), context: &mut TaskAContext, api: &'static dyn RuntimeApi) {
         1 => api
             .emit_event(MyEvents::SmallEvent.into())
             .expect("Failed to emit SmallEvent"),
-        2 => log!("TaskA"),
+        2 => logln!("TaskA"),
         3 => std::process::exit(0),
         _ => unreachable!(),
     }
@@ -51,7 +52,7 @@ fn task_a(_: (), context: &mut TaskAContext, api: &'static dyn RuntimeApi) {
 struct TaskBContext {}
 
 fn task_b(value: EventId, _: &mut TaskBContext, api: &'static dyn RuntimeApi) {
-    log!("TaskB: {}", value);
+    logln!("TaskB: {}", value);
 
     match value.into() {
         MyEvents::SmallEvent => api.clear_event_queue(),
@@ -63,14 +64,14 @@ fn task_b(value: EventId, _: &mut TaskBContext, api: &'static dyn RuntimeApi) {
 struct TaskCContext {}
 
 fn task_c(value: EventId, _: &mut TaskCContext, _: &'static dyn RuntimeApi) {
-    log!("TaskC: {}", value);
+    logln!("TaskC: {}", value);
 }
 
 #[derive(Default)]
 struct TaskDContext {}
 
 fn task_d(value: EventId, _: &mut TaskDContext, _: &'static dyn RuntimeApi) {
-    log!("TaskD: {}", value);
+    logln!("TaskD: {}", value);
 }
 
 static TASK_A_STORAGE: TaskletStorage<(), TaskAContext, 0> = TaskletStorage::new();

--- a/testbins/test-events/src/main.rs
+++ b/testbins/test-events/src/main.rs
@@ -1,5 +1,6 @@
 use aerugo::{
-    log, EventId, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage, AERUGO,
+    logln, EventId, InitApi, RuntimeApi, SystemHardwareConfig, TaskletConfig, TaskletStorage,
+    AERUGO,
 };
 
 enum MyEvents {
@@ -48,14 +49,14 @@ fn task_a(_: (), context: &mut TaskAContext, api: &'static dyn RuntimeApi) {
 struct TaskBContext {}
 
 fn task_b(value: EventId, _: &mut TaskBContext, _: &'static dyn RuntimeApi) {
-    log!("TaskB: {}", value);
+    logln!("TaskB: {}", value);
 }
 
 #[derive(Default)]
 struct TaskCContext {}
 
 fn task_c(value: EventId, _: &mut TaskCContext, _: &'static dyn RuntimeApi) {
-    log!("TaskC: {}", value);
+    logln!("TaskC: {}", value);
 }
 
 static TASK_A_STORAGE: TaskletStorage<(), TaskAContext, 0> = TaskletStorage::new();

--- a/testbins/test-hal-timer/Cargo.toml
+++ b/testbins/test-hal-timer/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 aerugo = { version = "0.1.0", path = "../..", features = [
     "use-aerugo-cortex-m",
     "rt",
-] }
+], default-features = false }
 calldwell = { version = "0.1.0", path = "../../calldwell/calldwell-rs" }
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.3", features = ["device"] }

--- a/testbins/test-hal-watchdog/Cargo.toml
+++ b/testbins/test-hal-watchdog/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 aerugo = { version = "0.1.0", path = "../..", features = [
     "use-aerugo-cortex-m",
     "rt",
-] }
+], default-features = false }
 calldwell = { version = "0.1.0", path = "../../calldwell/calldwell-rs" }
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.3", features = ["device"] }

--- a/testbins/test-message-queue/src/main.rs
+++ b/testbins/test-message-queue/src/main.rs
@@ -1,5 +1,5 @@
 use aerugo::{
-    log, InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
+    logln, InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
     TaskletConfig, TaskletStorage, AERUGO,
 };
 
@@ -25,7 +25,7 @@ fn task_a(_: (), context: &mut TaskAContext, _: &dyn RuntimeApi) {
 
 fn task_b(data: u8, context: &mut TaskBContext, _: &dyn RuntimeApi) {
     context.cnt += data;
-    log!("TaskB: {}", context.cnt);
+    logln!("TaskB: {}", context.cnt);
 
     if context.cnt == 5 {
         std::process::exit(0)
@@ -34,7 +34,7 @@ fn task_b(data: u8, context: &mut TaskBContext, _: &dyn RuntimeApi) {
 
 fn task_c(data: u8, context: &mut TaskCContext, _: &dyn RuntimeApi) {
     context.cnt += data;
-    log!("TaskC: {}", context.cnt);
+    logln!("TaskC: {}", context.cnt);
 
     if context.cnt == 5 {
         std::process::exit(0)

--- a/testbins/test-tasklet-priority-multiple-queues/src/main.rs
+++ b/testbins/test-tasklet-priority-multiple-queues/src/main.rs
@@ -1,5 +1,5 @@
 use aerugo::{
-    log, InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
+    logln, InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
     TaskletConfig, TaskletStorage, AERUGO,
 };
 
@@ -39,12 +39,12 @@ fn task_a(_: (), context: &mut TaskAContext, _: &dyn RuntimeApi) {
 
 fn task_b(data: u8, context: &mut TaskBContext, _: &dyn RuntimeApi) {
     context.cnt += data;
-    log!("TaskB: {}", context.cnt);
+    logln!("TaskB: {}", context.cnt);
 }
 
 fn task_c(data: u8, context: &mut TaskCContext, _: &dyn RuntimeApi) {
     context.cnt += data;
-    log!("TaskC: {}", context.cnt);
+    logln!("TaskC: {}", context.cnt);
 
     if context.cnt == 5 {
         std::process::exit(0)

--- a/testbins/test-tasklet-priority/src/main.rs
+++ b/testbins/test-tasklet-priority/src/main.rs
@@ -1,5 +1,5 @@
 use aerugo::{
-    log, InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
+    logln, InitApi, MessageQueueHandle, MessageQueueStorage, RuntimeApi, SystemHardwareConfig,
     TaskletConfig, TaskletStorage, AERUGO,
 };
 
@@ -25,7 +25,7 @@ fn task_a(_: (), context: &mut TaskAContext, _: &dyn RuntimeApi) {
 
 fn task_b(data: u8, context: &mut TaskBContext, _: &dyn RuntimeApi) {
     context.cnt += data;
-    log!("TaskB: {}", context.cnt);
+    logln!("TaskB: {}", context.cnt);
 
     if context.cnt == 5 {
         std::process::exit(0)
@@ -34,7 +34,7 @@ fn task_b(data: u8, context: &mut TaskBContext, _: &dyn RuntimeApi) {
 
 fn task_c(data: u8, context: &mut TaskCContext, _: &dyn RuntimeApi) {
     context.cnt += data;
-    log!("TaskC: {}", context.cnt);
+    logln!("TaskC: {}", context.cnt);
 
     if context.cnt == 5 {
         std::process::exit(0)

--- a/tests/requirements/test/test_hal_timer.py
+++ b/tests/requirements/test/test_hal_timer.py
@@ -1,7 +1,9 @@
 import logging
 from typing import List
 
-from test_utils import finish_test, init_test, setup_logger
+from test_utils import finish_test, init_test
+
+from calldwell import init_default_logger
 
 TEST_NAME = "test-hal-timer"
 
@@ -52,5 +54,5 @@ def main():
 
 
 if __name__ == "__main__":
-    setup_logger()
+    init_default_logger()
     main()

--- a/tests/requirements/test/test_hal_watchdog.py
+++ b/tests/requirements/test/test_hal_watchdog.py
@@ -1,6 +1,8 @@
 import logging
 
-from test_utils import finish_test, init_test, setup_logger
+from test_utils import finish_test, init_test
+
+from calldwell import init_default_logger
 
 TEST_NAME = "test-hal-watchdog"
 
@@ -35,5 +37,5 @@ def main():
 
 
 if __name__ == "__main__":
-    setup_logger()
+    init_default_logger()
     main()

--- a/tests/requirements/test/test_utils.py
+++ b/tests/requirements/test/test_utils.py
@@ -18,12 +18,6 @@ TEST_BINS_DIRECTORY = Path("./testbins")
 TARGET_NAME = "thumbv7em-none-eabihf"
 
 
-def setup_logger():
-    logging.basicConfig(
-        level=logging.INFO, format="[%(asctime)s] <%(levelname)s|%(name)s>: %(message)s"
-    )
-
-
 def init_test(test_name: str) -> Tuple[GDBClient, CalldwellRTTClient, SSHClient]:
     """Creates SSH connection to target board, initializes Calldwell"""
     project_path = TEST_BINS_DIRECTORY / test_name


### PR DESCRIPTION
* Added logging facilities for Cortex-M platforms
* Added `log` feature to Aerugo that's on by default. It allows to conditionally disable all logging facilities, if not needed/wanted in project - for example, if it's not required for operation (saves memory), or steals peripherals that are used by other libraries
* Modified logging API
  * Added `init_log` which is automatically called by `Aerugo::initialize`,
  * Added `logln` macro, refactored `log` into `logln` where applicable
* Moved init of Python `logging` module to Calldwell, for uniform log format with timestamps