### PR TITLE
ROS#177: Added UART logging to SCB tests

### DIFF
--- a/tests/requirements/test/test_hal_scb.py
+++ b/tests/requirements/test/test_hal_scb.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import logging
+import sys
+
 from test_utils import finish_test, init_test, wait_for_messages
 
 from calldwell import init_default_logger
+from calldwell.uart import RemoteUARTConfig, RemoteUARTConnection
+from scripts.env import (
+    BOARD_UART_DEVICE,
+    BOARD_UART_PORT,
+)
 
 TEST_NAME = "test-hal-scb"
 
@@ -12,6 +20,19 @@ TEST_NAME = "test-hal-scb"
 def main() -> None:
     """Main function of integration test."""
     _, rtt, ssh = init_test(TEST_NAME)
+
+    # Open UART connection and perform a handshake with test app
+    uart_config = RemoteUARTConfig(
+        device_path=BOARD_UART_DEVICE,
+        port=BOARD_UART_PORT,
+        baudrate=57600,
+    )
+    uart = RemoteUARTConnection(ssh, uart_config)
+    if not uart.open_uart():
+        logging.critical("TEST FAILED, could not establish UART connection!")
+        sys.exit(1000)
+
+    perform_uart_handshake(uart)
 
     wait_for_messages(
         rtt,
@@ -23,7 +44,48 @@ def main() -> None:
         ],
     )
 
+    uart.close_uart()
     finish_test(ssh)
+
+
+def perform_uart_handshake(uart: RemoteUARTConnection) -> None:
+    """Performs simple UART handshake with test app"""
+    handshake_message = b"Hello!"
+    expected_response = "World!"
+
+    logging.info("Performing UART handshake...")
+    written_bytes, tx_error = uart.write_bytes(handshake_message)
+
+    if tx_error is not None:
+        logging.critical(
+            f"TEST FAILED, an error occurred while sending handshake message: {tx_error}",
+        )
+        sys.exit(10)
+
+    if written_bytes != len(handshake_message):
+        logging.critical(
+            f"TEST FAILED, handshake message is not fully transmitted (sent {written_bytes} out of "
+            f"{len(handshake_message)} bytes)",
+        )
+        sys.exit(20)
+
+    response = uart.read_string(b"!")
+
+    if response.is_err:
+        logging.critical(
+            f"TEST FAILED, an error occurred while receiving handshake response: "
+            f"{response.unwrap_err()}",
+        )
+        sys.exit(30)
+
+    if (response_message := response.unwrap()) != expected_response:
+        logging.critical(
+            f"TEST FAILED, invalid handshake response\nexpected '{expected_response}'\ngot "
+            f"'{response_message}'",
+        )
+        sys.exit(40)
+
+    logging.info("UART handshake successful!")
 
 
 if __name__ == "__main__":

--- a/tests/requirements/test/test_hal_scb.py
+++ b/tests/requirements/test/test_hal_scb.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 
-from test_utils import finish_test, init_test, wait_for_messages
+from test_utils import finish_test, init_test, wait_for_messages, wait_for_uart_messages
 
 from calldwell import init_default_logger
 from calldwell.uart import RemoteUARTConfig, RemoteUARTConnection
@@ -38,9 +38,16 @@ def main() -> None:
         rtt,
         ssh,
         [
-            "icache tests successful",
-            "dcache tests successful",
-            "all tests finished successfully",
+            "I-Cache management test successful",
+        ],
+    )
+
+    wait_for_uart_messages(
+        uart,
+        ssh,
+        [
+            "D-Cache management test successful",
+            "All SCB tests finished successfully!",
         ],
     )
 

--- a/tests/requirements/test/test_hal_scb.rs
+++ b/tests/requirements/test/test_hal_scb.rs
@@ -1,9 +1,9 @@
 // Test scenario:
-// - Verify that icache can be disabled/enabled/cleared
-// - Verify that dcache can be disabled/enabled/cleared
-// TODO: SCB-030 requirement coverage
+// - Verify that I-Cache can be disabled/enabled/invalidated
+// - Verify that D-Cache can be disabled/enabled/cleared/invalidated
 
 /// @SRS{ROS-FUN-BSP-SCB-020}
+/// @SRS{ROS-FUN-BSP-SCB-030}
 /// @SRS{ROS-FUN-BSP-SCB-040}
 /// @SRS{ROS-FUN-BSP-SCB-050}
 /// @SRS{ROS-FUN-BSP-SCB-060}


### PR DESCRIPTION
This PR contains a SCB integration tests refactor, which makes this test switch to UART logs from RTT logs, as RTT logs become unreliable after D-Cache is enabled and disabled.